### PR TITLE
Re-add support for generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Components in **Kobold** are created by annotating a _render function_ with a `#
 use kobold::prelude::*;
 
 #[component]
-fn Hello(name: &str) -> impl Html {
+fn Hello(name: &str) -> impl Html + '_ {
     html! {
         <h1>"Hello "{ name }"!"</h1>
     }
@@ -168,7 +168,7 @@ state without unnecessary clones:
 ```rust
 # use kobold::prelude::*;
 #[component]
-fn Users(names: &[&str]) -> impl Html {
+fn Users<'a>(names: &'a [&'a str]) -> impl Html + 'a {
     html! {
         <ul>
         {
@@ -211,7 +211,7 @@ use kobold::prelude::*;
 
 // Capture children into the argument `n`
 #[component(children: n)]
-fn AddTen(n: i32) -> impl Html {
+fn AddTen(n: i32) -> i32 {
     // integers implement `Html` so they can be passed by value
     n + 10
 }

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -31,7 +31,7 @@
 //! use kobold::prelude::*;
 //!
 //! #[component]
-//! fn Hello(name: &str) -> impl Html {
+//! fn Hello(name: &str) -> impl Html + '_ {
 //!     html! {
 //!         <h1>"Hello "{ name }"!"</h1>
 //!     }
@@ -166,7 +166,7 @@
 //! ```
 //! # use kobold::prelude::*;
 //! #[component]
-//! fn Users(names: &[&str]) -> impl Html {
+//! fn Users<'a>(names: &'a [&'a str]) -> impl Html + 'a {
 //!     html! {
 //!         <ul>
 //!         {

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -209,7 +209,7 @@
 //!
 //! // Capture children into the argument `n`
 //! #[component(children: n)]
-//! fn AddTen(n: i32) -> impl Html {
+//! fn AddTen(n: i32) -> i32 {
 //!     // integers implement `Html` so they can be passed by value
 //!     n + 10
 //! }

--- a/crates/kobold_macros/src/lib.rs
+++ b/crates/kobold_macros/src/lib.rs
@@ -34,7 +34,11 @@ macro_rules! unwrap_err {
 pub fn component(args: TokenStream, input: TokenStream) -> TokenStream {
     let args = unwrap_err!(fn_component::args(args));
 
-    unwrap_err!(fn_component::component(args, input))
+    let out = unwrap_err!(fn_component::component(args, input));
+
+    // panic!("{out}");
+
+    out
 }
 
 #[allow(clippy::let_and_return)]

--- a/crates/kobold_macros/src/syntax.rs
+++ b/crates/kobold_macros/src/syntax.rs
@@ -43,6 +43,16 @@ impl Parse for Generics {
     }
 }
 
+impl Tokenize for Generics {
+    fn tokenize(self) -> TokenStream {
+        self.tokens
+    }
+
+    fn tokenize_in(self, stream: &mut TokenStream) {
+        stream.extend(self.tokens);
+    }
+}
+
 /// CSS-style label, matches sequences of identifiers with dashes allowed.
 pub struct CssLabel {
     pub label: String,

--- a/crates/kobold_macros/src/tokenize.rs
+++ b/crates/kobold_macros/src/tokenize.rs
@@ -62,6 +62,24 @@ impl Tokenize for TokenStream {
     }
 }
 
+impl<T: Tokenize> Tokenize for Option<T> {
+    fn tokenize_in(self, stream: &mut TokenStream) {
+        if let Some(item) = self {
+            item.tokenize_in(stream)
+        }
+    }
+}
+
+impl<T: Tokenize + Clone> Tokenize for &T {
+    fn tokenize(self) -> TokenStream {
+        self.clone().tokenize()
+    }
+
+    fn tokenize_in(self, stream: &mut TokenStream) {
+        self.clone().tokenize_in(stream);
+    }
+}
+
 pub struct TokenizeIter<I>(I);
 
 impl<I> Tokenize for TokenizeIter<I>

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -1,7 +1,7 @@
 use kobold::prelude::*;
 
 #[component]
-fn Hello(name: &str) -> impl Html {
+fn Hello(name: &str) -> impl Html + '_ {
     html! {
         <h1>"Hello "{ name }"!"</h1>
     }

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -66,7 +66,7 @@ fn App() -> impl Html {
 }
 
 #[component]
-fn EntryInput(state: &Hook<State>) -> impl Html {
+fn EntryInput(state: &Hook<State>) -> impl Html + '_ {
     html! {
         <input
             .new-todo
@@ -83,7 +83,7 @@ fn EntryInput(state: &Hook<State>) -> impl Html {
 }
 
 #[component]
-fn ToggleAll(active_count: usize, state: &Hook<State>) -> impl Html {
+fn ToggleAll(active_count: usize, state: &Hook<State>) -> impl Html + '_ {
     let onclick = state.bind(move |state, _| state.set_all(active_count != 0));
 
     html! {
@@ -93,7 +93,7 @@ fn ToggleAll(active_count: usize, state: &Hook<State>) -> impl Html {
 }
 
 #[component]
-fn EntryView(idx: usize, entry: &Entry, state: &Hook<State>) -> impl Html {
+fn EntryView<'a>(idx: usize, entry: &'a Entry, state: &'a Hook<State>) -> impl Html + 'a {
     let input = entry.editing.then(move || {
         let onmouseover = state.bind(move |_, event: &MouseEvent<InputElement>| {
             let _ = event.target().focus();
@@ -141,7 +141,7 @@ fn EntryView(idx: usize, entry: &Entry, state: &Hook<State>) -> impl Html {
 }
 
 #[component(children)]
-fn FilterView(filter: Filter, state: &Hook<State>, children: impl Html + 'static) -> impl Html {
+fn FilterView<'a>(filter: Filter, state: &'a Hook<State>, children: impl Html + 'a) -> impl Html + 'a {
     let selected = state.filter;
 
     let class = if selected == filter {

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -140,12 +140,8 @@ fn EntryView<'a>(idx: usize, entry: &'a Entry, state: &'a Hook<State>) -> impl H
     }
 }
 
-#[component(children)]
-fn FilterView<'a>(
-    filter: Filter,
-    state: &'a Hook<State>,
-    children: impl Html + 'a,
-) -> impl Html + 'a {
+#[component(children: label)]
+fn FilterView<'a>(filter: Filter, state: &'a Hook<State>, label: impl Html + 'a) -> impl Html + 'a {
     let selected = state.filter;
 
     let class = if selected == filter {
@@ -158,7 +154,7 @@ fn FilterView<'a>(
 
     html! {
         <li>
-            <a {class} {href} {onclick}>{ children }</a>
+            <a {class} {href} {onclick}>{ label }</a>
         </li>
     }
 }

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -141,7 +141,11 @@ fn EntryView<'a>(idx: usize, entry: &'a Entry, state: &'a Hook<State>) -> impl H
 }
 
 #[component(children)]
-fn FilterView<'a>(filter: Filter, state: &'a Hook<State>, children: impl Html + 'a) -> impl Html + 'a {
+fn FilterView<'a>(
+    filter: Filter,
+    state: &'a Hook<State>,
+    children: impl Html + 'a,
+) -> impl Html + 'a {
     let selected = state.filter;
 
     let class = if selected == filter {


### PR DESCRIPTION
Also return types are now taken verbatim. Unfortunately we need to annotate lifetimes in places, but it all feels more first-class Rust.