### PR TITLE
Remove [patch.crates-io]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,6 @@ members = [
     "examples/*",
 ]
 
-[patch.crates-io]
-kobold = { path = "crates/kobold" }
-kobold_macros = { path = "crates/kobold_macros" }
-kobold_qr = { path = "crates/kobold_qr" }
-
 [profile.release]
 lto = "fat"
 codegen-units = 1


### PR DESCRIPTION
Not necessary after merging #23.