### PR TITLE
`Html` -> `View`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,18 @@ while leveraging Rust's powerful type system for safety and performance.
 
 Like in [React](https://reactjs.org/) or [Yew](https://yew.rs/) updates are done by repeating calls
 to a render function whenever the state changes. However, unlike either, **Kobold** does not produce a
-full blown [virtual DOM](https://en.wikipedia.org/wiki/Virtual_DOM). Instead the [`html!`](html) macro compiles
-all static HTML elements to a single JavaScript function that constructs the exact
-[DOM](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model) for it.
+full blown [virtual DOM](https://en.wikipedia.org/wiki/Virtual_DOM). Instead the `view!` macro compiles
+all static [DOM](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model) elements to a single
+JavaScript function that constructs them.
 
-All expressions, which must implement the [`Html`](Html) trait, are injected into the constructed DOM on first
+All expressions, which must implement the `View` trait, are injected into the constructed DOM on first
 render. Kobold keeps track of the DOM node references for these expressions. Since the exact types the
 expressions evaluate to are known to the Rust compiler, update calls can diff them by value and surgically
 update the DOM should they change. Changing a string or an integer only updates the exact
 [`Text` node](https://developer.mozilla.org/en-US/docs/Web/API/Text) that string or integer was rendered to.
 
-_If the `html!` macro invocation contains HTML elements with no expressions, the constructed `Html`
-type will be zero-sized, and its `Html::update` method will be empty, making updates of static
+_If the `view!` macro invocation contains HTML elements with no expressions, the constructed `View`
+type will be zero-sized, and its `View::update` method will be empty, making updates of static
 HTML quite literally zero-cost._
 
 ### Hello World!
@@ -33,22 +33,22 @@ Components in **Kobold** are created by annotating a _render function_ with a `#
 use kobold::prelude::*;
 
 #[component]
-fn Hello(name: &str) -> impl Html + '_ {
-    html! {
+fn Hello(name: &str) -> impl View + '_ {
+    view! {
         <h1>"Hello "{ name }"!"</h1>
     }
 }
 
 fn main() {
-    kobold::start(html! {
+    kobold::start(view! {
         <Hello name="Kobold" />
     });
 }
 ```
 
-The _render function_ must return a type that implements the `Html` trait. Since the `html!` macro
+The _render function_ must return a type that implements the `View` trait. Since the `view!` macro
 produces _transient types_, or [_Voldemort types_](https://wiki.dlang.org/Voldemort_types), the best approach
-here is to always use the `impl Html` return type.
+here is to always use the `impl View` return type.
 
 Everything here is statically typed and the macro doesn't delete any information when manipulating the
 token stream, so the Rust compiler can tell you when you've made a mistake:
@@ -66,18 +66,21 @@ and it will change the invocations inside the macros for you.
 
 ### Stateful components
 
-The [`stateful`](stateful::stateful) function can be used to create components that own and manipulate
+The `stateful` function can be used to create components that own and manipulate
 their state:
 
 ```rust
 use kobold::prelude::*;
 
 #[component]
-fn Counter() -> impl Html {
-    stateful(0_u32, |count| {
-        let onclick = count.bind(|count, _event| *count += 1);
+fn Counter(init: u32) -> impl View {
+    stateful(init, |count| {
+        bind! { count:
+            // Create an event handler with access to `&mut u32`
+            let onclick = move |_event| *count += 1;
+        }
 
-        html! {
+        view! {
             <p>
                 "You clicked on the "
                 // `{onclick}` here is shorthand for `onclick={onclick}`
@@ -89,8 +92,8 @@ fn Counter() -> impl Html {
 }
 
 fn main() {
-    kobold::start(html! {
-        <Counter />
+    kobold::start(view! {
+        <Counter init={0} />
     });
 }
 ```
@@ -99,31 +102,31 @@ The `stateful` function takes two parameters:
 
 * State constructor that implements the `IntoState` trait. **Kobold** comes with default
   implementations for most primitive types, so we can use `u32` here.
-* The anonymous render function that uses the constructed state, in our case `fn(&Hook<u32>) -> impl Html`.
+* The anonymous render function that uses the constructed state, in our case its argument is `&Hook<u32>`.
 
 The `Hook` here is a smart pointer to the state itself that allows non-mutable access to the
-state, as well as the `bind` method for creating event callbacks. These take a `&mut`
-reference to the state and a `&` reference to a DOM `Event` (ignored above).
+state. The `bind!` macro can be invoked for any `Hook` to create closures with `&mut` references to the
+underlying state.
 
 For more details visit the [`stateful` module documentation](https://docs.rs/kobold/latest/kobold/stateful/index.html).
 
 ### Conditional rendering
 
-Because the `html!` macro produces unique transient types, `if` and `match` expressions that invoke
+Because the `view!` macro produces unique transient types, `if` and `match` expressions that invoke
 the macro will naturally fail to compile.
 
 Using the `auto_branch` flag on the `#[component]` attribute
-**Kobold** will scan the body of of your component render function, and make all `html!` macro invocations
+**Kobold** will scan the body of of your component render function, and make all `view!` macro invocations
 inside an `if` or `match` expression, and wrap them in an enum making them the same type:
 
 
 ```rust
 #[component(auto_branch)]
-fn Conditional(illuminatus: bool) -> impl Html {
+fn Conditional(illuminatus: bool) -> impl View {
     if illuminatus {
-        html! { <p>"It was the year when they finally immanentized the Eschaton."</p> }
+        view! { <p>"It was the year when they finally immanentized the Eschaton."</p> }
     } else {
-        html! { <blockquote>"It was love at first sight."</blockquote> }
+        view! { <blockquote>"It was love at first sight."</blockquote> }
     }
 }
 ```
@@ -140,12 +143,12 @@ To render an iterator use the `list` method from the
 use kobold::prelude::*;
 
 #[component]
-fn IterateNumbers(count: u32) -> impl Html {
-    html! {
+fn IterateNumbers(count: u32) -> impl View {
+    view! {
         <ul>
         {
             (1..=count)
-                .map(|n| html! { <li>"Item #"{n}</li> })
+                .map(|n| view! { <li>"Item #"{n}</li> })
                 .list()
         }
         </ul>
@@ -153,26 +156,26 @@ fn IterateNumbers(count: u32) -> impl Html {
 }
 ```
 
-This wraps the iterator in the transparent `List<_>` type that implements `Html`.
+This wraps the iterator in the transparent `List<_>` type that implements `View`.
 On updates the iterator is consumed once and all items are diffed with the previous version.
 No allocations are made by **Kobold** when updating such a list, unless the rendered list needs
 to grow past its original capacity.
 
 ### Borrowed values
 
-`Html` types are truly transient and only need to live for the duration of the initial render,
+`View` types are truly transient and only need to live for the duration of the initial render,
 or for the duration of the subsequent update. This means that you can easily and cheaply render borrowed
 state without unnecessary clones:
 
 ```rust
 #[component]
-fn Users<'a>(names: &'a [&'a str]) -> impl Html + 'a {
-    html! {
+fn Users<'a>(names: &'a [&'a str]) -> impl View + 'a {
+    view! {
         <ul>
         {
             names
                 .iter()
-                .map(|name| html! { <li>{ name }</li> })
+                .map(|name| view! { <li>{ name }</li> })
                 .list()
         }
         </ul>
@@ -182,21 +185,21 @@ fn Users<'a>(names: &'a [&'a str]) -> impl Html + 'a {
 
 ### Components with children
 
-If you wish to capture children from parent `html!` invocation, simply change
+If you wish to capture children from parent `view!` invocation, simply change
 `#[component]` to `#[component(children)]`:
 
 ```rust
 use kobold::prelude::*;
 
 #[component(children)]
-fn Header(children: impl Html) -> impl Html {
-    html! {
+fn Header(children: impl View) -> impl View {
+    view! {
         <header><h1>{ children }</h1></header>
     }
 }
 
 fn main() {
-    kobold::start(html! {
+    kobold::start(view! {
         <Header>"Hello Kobold"</Header>
     });
 }
@@ -210,12 +213,12 @@ use kobold::prelude::*;
 // Capture children into the argument `n`
 #[component(children: n)]
 fn AddTen(n: i32) -> i32 {
-    // integers implement `Html` so they can be passed by value
+    // integers implement `View` so they can be passed by value
     n + 10
 }
 
 fn main() {
-    kobold::start(html! {
+    kobold::start(view! {
         <p>
             "Meaning of life is "
             <AddTen>{ 32 }</AddTen>

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ error[E0560]: struct `Hello` has no field named `nam`
 You can even use [rust-analyzer](https://rust-analyzer.github.io/) to refactor component or field names,
 and it will change the invocations inside the macros for you.
 
-### Stateful components
+### Stateful
 
-The `stateful` function can be used to create components that own and manipulate
+The `stateful` function can be used to create views that own and manipulate
 their state:
 
 ```rust

--- a/crates/kobold/Cargo.toml
+++ b/crates/kobold/Cargo.toml
@@ -11,6 +11,10 @@ description = "Easy declarative web interfaces"
 repository = "https://github.com/maciejhirsz/kobold"
 documentation = "https://docs.rs/kobold"
 
+[features]
+default = ["stateful"]
+stateful = []
+
 [dependencies]
 wasm-bindgen = "0.2.84"
 itoa = "1.0.1"

--- a/crates/kobold/src/attribute.rs
+++ b/crates/kobold/src/attribute.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::JsValue;
 
 use crate::util;
 use crate::value::{FastDiff, NoDiff, Stringify};
-use crate::{Element, View, Mountable};
+use crate::{Element, Mountable, View};
 
 pub trait Attribute {
     type Abi: IntoWasmAbi;

--- a/crates/kobold/src/attribute.rs
+++ b/crates/kobold/src/attribute.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::JsValue;
 
 use crate::util;
 use crate::value::{FastDiff, NoDiff, Stringify};
-use crate::{Element, Html, Mountable};
+use crate::{Element, View, Mountable};
 
 pub trait Attribute {
     type Abi: IntoWasmAbi;
@@ -38,7 +38,7 @@ impl<V> AttributeNode<V> {
     }
 }
 
-impl Html for AttributeNode<String> {
+impl View for AttributeNode<String> {
     type Product = AttributeNodeProduct<String>;
 
     fn build(self) -> Self::Product {
@@ -58,7 +58,7 @@ impl Html for AttributeNode<String> {
     }
 }
 
-impl Html for AttributeNode<&String> {
+impl View for AttributeNode<&String> {
     type Product = AttributeNodeProduct<String>;
 
     fn build(self) -> Self::Product {
@@ -78,7 +78,7 @@ impl Html for AttributeNode<&String> {
     }
 }
 
-impl<S> Html for AttributeNode<S>
+impl<S> View for AttributeNode<S>
 where
     S: Stringify + Eq + Copy + 'static,
 {
@@ -101,7 +101,7 @@ where
     }
 }
 
-impl<S> Html for AttributeNode<NoDiff<S>>
+impl<S> View for AttributeNode<NoDiff<S>>
 where
     S: Stringify,
 {
@@ -114,7 +114,7 @@ where
     fn update(self, _: &mut Self::Product) {}
 }
 
-impl Html for AttributeNode<FastDiff<'_>> {
+impl View for AttributeNode<FastDiff<'_>> {
     type Product = AttributeNodeProduct<usize>;
 
     fn build(self) -> Self::Product {

--- a/crates/kobold/src/branching.rs
+++ b/crates/kobold/src/branching.rs
@@ -88,7 +88,7 @@
 
 use web_sys::Node;
 
-use crate::{Element, View, Mountable};
+use crate::{Element, Mountable, View};
 
 macro_rules! branch {
     ($name:ident < $($var:ident),* >) => {

--- a/crates/kobold/src/branching.rs
+++ b/crates/kobold/src/branching.rs
@@ -1,15 +1,15 @@
 //! # Utilities for conditional rendering
 //!
-//! The [`html!`](crate::html) macro produces unique transient types, so you might run into compile errors when branching:
+//! The [`view!`](crate::view) macro produces unique transient types, so you might run into compile errors when branching:
 //!
 //! ```compile_fail
 //! # use kobold::prelude::*;
 //! #[component]
-//! fn Conditional(illuminatus: bool) -> impl Html {
+//! fn Conditional(illuminatus: bool) -> impl View {
 //!     if illuminatus {
-//!         html! { <p>"It was the year when they finally immanentized the Eschaton."</p> }
+//!         view! { <p>"It was the year when they finally immanentized the Eschaton."</p> }
 //!     } else {
-//!         html! { <blockquote>"It was love at first sight."</blockquote> }
+//!         view! { <blockquote>"It was love at first sight."</blockquote> }
 //!     }
 //! }
 //! ```
@@ -18,10 +18,10 @@
 //!
 //! ```text
 //! /     if illuminatus {
-//! |         html! { <p>"It was the year when they finally immanentized the Eschaton."</p> }
+//! |         view! { <p>"It was the year when they finally immanentized the Eschaton."</p> }
 //! |         ------------------------------------------------------------------------------- expected because of this
 //! |     } else {
-//! |         html! { <blockquote>"It was love at first sight."</blockquote> }
+//! |         view! { <blockquote>"It was love at first sight."</blockquote> }
 //! |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `Conditional::render::Transient`, found a different struct `Conditional::render::Transient`
 //! |     }
 //! |_____- `if` and `else` have incompatible types
@@ -34,11 +34,11 @@
 //! ```
 //! # use kobold::prelude::*;
 //! #[component(auto_branch)]
-//! fn Conditional(illuminatus: bool) -> impl Html {
+//! fn Conditional(illuminatus: bool) -> impl View {
 //!     if illuminatus {
-//!         html! { <p>"It was the year when they finally immanentized the Eschaton."</p> }
+//!         view! { <p>"It was the year when they finally immanentized the Eschaton."</p> }
 //!     } else {
-//!         html! { <blockquote>"It was love at first sight."</blockquote> }
+//!         view! { <blockquote>"It was love at first sight."</blockquote> }
 //!     }
 //! }
 //! ```
@@ -55,13 +55,13 @@
 //! use kobold::branching::Branch2;
 //!
 //! #[component]
-//! fn Conditional(illuminatus: bool) -> impl Html {
+//! fn Conditional(illuminatus: bool) -> impl View {
 //!     if illuminatus {
-//!         Branch2::A(html! {
+//!         Branch2::A(view! {
 //!             <p>"It was the year when they finally immanentized the Eschaton."</p>
 //!         })
 //!     } else {
-//!         Branch2::B(html! {
+//!         Branch2::B(view! {
 //!             <blockquote>"It was love at first sight."</blockquote>
 //!         })
 //!     }
@@ -75,9 +75,9 @@
 //! ```
 //! # use kobold::prelude::*;
 //! #[component]
-//! fn Conditional(illuminatus: bool) -> impl Html {
+//! fn Conditional(illuminatus: bool) -> impl View {
 //!     if illuminatus {
-//!         Some(html! {
+//!         Some(view! {
 //!             <p>"It was the year when they finally immanentized the Eschaton."</p>
 //!         })
 //!     } else {
@@ -88,7 +88,7 @@
 
 use web_sys::Node;
 
-use crate::{Element, Html, Mountable};
+use crate::{Element, View, Mountable};
 
 macro_rules! branch {
     ($name:ident < $($var:ident),* >) => {
@@ -98,10 +98,10 @@ macro_rules! branch {
             )*
         }
 
-        impl<$($var),*> Html for $name<$($var),*>
+        impl<$($var),*> View for $name<$($var),*>
         where
             $(
-                $var: Html,
+                $var: View,
             )*
         {
             type Product = $name<$($var::Product),*>;
@@ -172,7 +172,7 @@ impl Mountable for EmptyNode {
     }
 }
 
-impl Html for Empty {
+impl View for Empty {
     type Product = EmptyNode;
 
     fn build(self) -> Self::Product {
@@ -182,7 +182,7 @@ impl Html for Empty {
     fn update(self, _: &mut Self::Product) {}
 }
 
-impl<T: Html> Html for Option<T> {
+impl<T: View> View for Option<T> {
     type Product = Branch2<T::Product, EmptyNode>;
 
     fn build(self) -> Self::Product {

--- a/crates/kobold/src/event.rs
+++ b/crates/kobold/src/event.rs
@@ -7,7 +7,7 @@ use wasm_bindgen::closure::Closure;
 use wasm_bindgen::{JsCast, JsValue};
 use web_sys::HtmlElement;
 
-use crate::{Element, View, Mountable};
+use crate::{Element, Mountable, View};
 
 /// Smart wrapper around a [`web_sys::Event`](web_sys::Event) which includes type
 /// information for the target element of said event.

--- a/crates/kobold/src/event.rs
+++ b/crates/kobold/src/event.rs
@@ -7,7 +7,7 @@ use wasm_bindgen::closure::Closure;
 use wasm_bindgen::{JsCast, JsValue};
 use web_sys::HtmlElement;
 
-use crate::{Element, Html, Mountable};
+use crate::{Element, View, Mountable};
 
 /// Smart wrapper around a [`web_sys::Event`](web_sys::Event) which includes type
 /// information for the target element of said event.
@@ -99,7 +99,7 @@ where
     }
 }
 
-impl<F> Html for EventHandler<F>
+impl<F> View for EventHandler<F>
 where
     F: Fn(web_sys::Event) + 'static,
 {

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -9,18 +9,18 @@
 //!
 //! Like in [React](https://reactjs.org/) or [Yew](https://yew.rs/) updates are done by repeating calls
 //! to a render function whenever the state changes. However, unlike either, **Kobold** does not produce a
-//! full blown [virtual DOM](https://en.wikipedia.org/wiki/Virtual_DOM). Instead the [`html!`](html) macro compiles
-//! all static HTML elements to a single JavaScript function that constructs the exact
-//! [DOM](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model) for it.
+//! full blown [virtual DOM](https://en.wikipedia.org/wiki/Virtual_DOM). Instead the [`view!`](view) macro compiles
+//! all static [DOM](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model) elements to a single
+//! JavaScript function that constructs them.
 //!
-//! All expressions, which must implement the [`Html`](Html) trait, are injected into the constructed DOM on first
+//! All expressions, which must implement the [`View`](View) trait, are injected into the constructed DOM on first
 //! render. Kobold keeps track of the DOM node references for these expressions. Since the exact types the
 //! expressions evaluate to are known to the Rust compiler, update calls can diff them by value and surgically
 //! update the DOM should they change. Changing a string or an integer only updates the exact
 //! [`Text` node](https://developer.mozilla.org/en-US/docs/Web/API/Text) that string or integer was rendered to.
 //!
-//! _If the [`html!`](html) macro invocation contains HTML elements with no expressions, the constructed [`Html`](Html)
-//! type will be zero-sized, and its [`Html::update`](Html::update) method will be empty, making updates of static
+//! _If the [`view!`](view) macro invocation contains HTML elements with no expressions, the constructed [`View`](View)
+//! type will be zero-sized, and its [`View::update`](View::update) method will be empty, making updates of static
 //! HTML quite literally zero-cost._
 //!
 //! ### Hello World!
@@ -31,22 +31,22 @@
 //! use kobold::prelude::*;
 //!
 //! #[component]
-//! fn Hello(name: &str) -> impl Html + '_ {
-//!     html! {
+//! fn Hello(name: &str) -> impl View + '_ {
+//!     view! {
 //!         <h1>"Hello "{ name }"!"</h1>
 //!     }
 //! }
 //!
 //! fn main() {
-//!     kobold::start(html! {
+//!     kobold::start(view! {
 //!         <Hello name="Kobold" />
 //!     });
 //! }
 //! ```
 //!
-//! The _render function_ must return a type that implements the [`Html`](Html) trait. Since the [`html!`](html) macro
+//! The _render function_ must return a type that implements the [`View`](View) trait. Since the [`view!`](view) macro
 //! produces _transient types_, or [_Voldemort types_](https://wiki.dlang.org/Voldemort_types), the best approach
-//! here is to always use the `impl Html` return type.
+//! here is to always use the `impl View` return type.
 //!
 //! Everything here is statically typed and the macro doesn't delete any information when manipulating the
 //! token stream, so the Rust compiler can tell you when you've made a mistake:
@@ -71,11 +71,14 @@
 //! use kobold::prelude::*;
 //!
 //! #[component]
-//! fn Counter() -> impl Html {
-//!     stateful(0_u32, |count| {
-//!         let onclick = count.bind(|count, _event| *count += 1);
+//! fn Counter(init: u32) -> impl View {
+//!     stateful(init, |count| {
+//!         bind! { count:
+//!             // Create an event handler with access to `&mut u32`
+//!             let onclick = move |_event| *count += 1;
+//!         }
 //!
-//!         html! {
+//!         view! {
 //!             <p>
 //!                 "You clicked on the "
 //!                 // `{onclick}` here is shorthand for `onclick={onclick}`
@@ -87,8 +90,8 @@
 //! }
 //!
 //! fn main() {
-//!     kobold::start(html! {
-//!         <Counter />
+//!     kobold::start(view! {
+//!         <Counter init={0} />
 //!     });
 //! }
 //! ```
@@ -97,32 +100,32 @@
 //!
 //! * State constructor that implements the [`IntoState`](stateful::IntoState) trait. **Kobold** comes with default
 //!   implementations for most primitive types, so we can use `u32` here.
-//! * The anonymous render function that uses the constructed state, in our case `fn(&Hook<u32>) -> impl Html`.
+//! * The anonymous render closure that uses the constructed state, in our case its argument is `&Hook<u32>`.
 //!
 //! The [`Hook`](stateful::Hook) here is a smart pointer to the state itself that allows non-mutable access to the
-//! state, as well as the [`bind`](stateful::Hook::bind) method for creating event callbacks. These take a `&mut`
-//! reference to the state and a `&` reference to a DOM [`Event`](event::Event) (ignored above).
+//! state. The [`bind!`](bind) macro can be invoked for any `Hook` to create closures with `&mut` references to the
+//! underlying state.
 //!
 //! For more details visit the [`stateful` module documentation](stateful).
 //!
 //! ### Conditional rendering
 //!
-//! Because the [`html!`](html) macro produces unique transient types, `if` and `match` expressions that invoke
+//! Because the [`view!`](view) macro produces unique transient types, `if` and `match` expressions that invoke
 //! the macro will naturally fail to compile.
 //!
 //! Using the [`auto_branch`](component#componentauto_branch) flag on the [`#[component]`](component) attribute
-//! **Kobold** will scan the body of of your component render function, and make all [`html!`](html) macro invocations
+//! **Kobold** will scan the body of of your component render function, and make all [`view!`](view) macro invocations
 //! inside an `if` or `match` expression, and wrap them in an enum making them the same type:
 //!
 //!
 //! ```
 //! # use kobold::prelude::*;
 //! #[component(auto_branch)]
-//! fn Conditional(illuminatus: bool) -> impl Html {
+//! fn Conditional(illuminatus: bool) -> impl View {
 //!     if illuminatus {
-//!         html! { <p>"It was the year when they finally immanentized the Eschaton."</p> }
+//!         view! { <p>"It was the year when they finally immanentized the Eschaton."</p> }
 //!     } else {
-//!         html! { <blockquote>"It was love at first sight."</blockquote> }
+//!         view! { <blockquote>"It was love at first sight."</blockquote> }
 //!     }
 //! }
 //! ```
@@ -139,12 +142,12 @@
 //! use kobold::prelude::*;
 //!
 //! #[component]
-//! fn IterateNumbers(count: u32) -> impl Html {
-//!     html! {
+//! fn IterateNumbers(count: u32) -> impl View {
+//!     view! {
 //!         <ul>
 //!         {
 //!             (1..=count)
-//!                 .map(|n| html! { <li>"Item #"{n}</li> })
+//!                 .map(|n| view! { <li>"Item #"{n}</li> })
 //!                 .list()
 //!         }
 //!         </ul>
@@ -152,27 +155,27 @@
 //! }
 //! ```
 //!
-//! This wraps the iterator in the transparent [`List<_>`](list::List) type that implements [`Html`](Html).
+//! This wraps the iterator in the transparent [`List<_>`](list::List) type that implements [`View`](View).
 //! On updates the iterator is consumed once and all items are diffed with the previous version.
 //! No allocations are made by **Kobold** when updating such a list, unless the rendered list needs
 //! to grow past its original capacity.
 //!
 //! ### Borrowed values
 //!
-//! [`Html`](Html) types are truly transient and only need to live for the duration of the initial render,
+//! [`View`](View) types are truly transient and only need to live for the duration of the initial render,
 //! or for the duration of the subsequent update. This means that you can easily and cheaply render borrowed
 //! state without unnecessary clones:
 //!
 //! ```
 //! # use kobold::prelude::*;
 //! #[component]
-//! fn Users<'a>(names: &'a [&'a str]) -> impl Html + 'a {
-//!     html! {
+//! fn Users<'a>(names: &'a [&'a str]) -> impl View + 'a {
+//!     view! {
 //!         <ul>
 //!         {
 //!             names
 //!                 .iter()
-//!                 .map(|name| html! { <li>{ name }</li> })
+//!                 .map(|name| view! { <li>{ name }</li> })
 //!                 .list()
 //!         }
 //!         </ul>
@@ -182,21 +185,21 @@
 //!
 //! ### Components with children
 //!
-//! If you wish to capture children from parent [`html!`](html) invocation, simply change
+//! If you wish to capture children from parent [`view!`](view) invocation, simply change
 //! `#[component]` to `#[component(children)]`:
 //!
 //! ```no_run
 //! use kobold::prelude::*;
 //!
 //! #[component(children)]
-//! fn Header(children: impl Html) -> impl Html {
-//!     html! {
+//! fn Header(children: impl View) -> impl View {
+//!     view! {
 //!         <header><h1>{ children }</h1></header>
 //!     }
 //! }
 //!
 //! fn main() {
-//!     kobold::start(html! {
+//!     kobold::start(view! {
 //!         <Header>"Hello Kobold"</Header>
 //!     });
 //! }
@@ -210,12 +213,12 @@
 //! // Capture children into the argument `n`
 //! #[component(children: n)]
 //! fn AddTen(n: i32) -> i32 {
-//!     // integers implement `Html` so they can be passed by value
+//!     // integers implement `View` so they can be passed by value
 //!     n + 10
 //! }
 //!
 //! fn main() {
-//!     kobold::start(html! {
+//!     kobold::start(view! {
 //!         <p>
 //!             "Meaning of life is "
 //!             <AddTen>{ 32 }</AddTen>
@@ -253,8 +256,8 @@
 /// ```
 /// # use kobold::prelude::*;
 /// #[component]
-/// fn MyComponent() -> impl Html {
-///     html! {
+/// fn MyComponent() -> impl View {
+///     view! {
 ///         <p>"Hello, world!"</p>
 ///     }
 /// }
@@ -267,7 +270,7 @@
 ///
 /// ### `#[component(auto_branch)]`
 ///
-/// Automatically resolve all invocations of the [`html!`](html) macro inside `if` and `match` expressions
+/// Automatically resolve all invocations of the [`view!`](view) macro inside `if` and `match` expressions
 /// to the same type.
 ///
 /// For more details visit the [`branching` module documentation](branching).
@@ -280,8 +283,8 @@
 /// * `#[component(children: my_name)]`: children will be captured by the `my_name` argument on the function.
 pub use kobold_macros::component;
 
-/// Macro for creating transient [`Html`](Html) types. See the [main documentation](crate) for details.
-pub use kobold_macros::html;
+/// Macro for creating transient [`View`](View) types. See the [main documentation](crate) for details.
+pub use kobold_macros::view;
 
 use wasm_bindgen::{JsCast, JsValue};
 
@@ -295,7 +298,12 @@ pub mod list;
 pub mod stateful;
 pub mod util;
 
-/// The prelude module with most commonly used types
+/// The prelude module with most commonly used types.
+///
+/// Intended use is:
+/// ```
+/// use kobold::prelude::*;
+/// ```
 pub mod prelude {
     pub use crate::event::{Event, KeyboardEvent, MouseEvent};
     pub use crate::list::ListIteratorExt as _;
@@ -304,19 +312,19 @@ pub mod prelude {
     // pub use crate::stateful::{ShouldRender, WeakHook};
     // pub use crate::stateful::{stateful, Hook, IntoState, ShouldRender, WeakHook};
     pub use crate::value::{StrExt as _, Stringify as _};
-    pub use crate::{component, html, Html};
+    pub use crate::{component, view, View};
 }
 
 use dom::Element;
 
-/// Crate re-exports for the [`html!`](html) macro internals
+/// Crate re-exports for the [`view!`](view) macro internals
 pub mod reexport {
     pub use wasm_bindgen;
     pub use web_sys;
 }
 
 /// Trait that describes types that can be rendered in the DOM.
-pub trait Html {
+pub trait View {
     /// HTML product of this type, this is effectively the strongly-typed
     /// virtual DOM equivalent for Kobold.
     type Product: Mountable;
@@ -355,9 +363,9 @@ pub struct OnMount<H, F> {
     handler: F,
 }
 
-impl<H, F> Html for OnMount<H, F>
+impl<H, F> View for OnMount<H, F>
 where
-    H: Html,
+    H: View,
     F: FnOnce(&<H::Product as Mountable>::Js),
 {
     type Product = H::Product;
@@ -380,9 +388,9 @@ pub struct OnRender<H, F> {
     handler: F,
 }
 
-impl<H, F> Html for OnRender<H, F>
+impl<H, F> View for OnRender<H, F>
 where
-    H: Html,
+    H: View,
     F: FnOnce(&<H::Product as Mountable>::Js),
 {
     type Product = H::Product;
@@ -413,8 +421,8 @@ pub trait Mountable: 'static {
     }
 }
 
-/// Start the Kobold app by mounting given [`Html`](Html) in the document `body`.
-pub fn start(html: impl Html) {
+/// Start the Kobold app by mounting given [`View`](View) in the document `body`.
+pub fn start(html: impl View) {
     init_panic_hook();
 
     use std::mem::ManuallyDrop;
@@ -457,6 +465,32 @@ macro_rules! class {
     };
 }
 
+/// Binds a closure to a given [`Hook`](stateful::Hook). In practice:
+///
+/// ```
+/// # use kobold::{bind, stateful::Hook};
+/// # fn test(count: &Hook<i32>) {
+/// bind! { count:
+///     let increment = move |_| *count += 1;
+///     let decrement = move |_| *count -= 1;
+/// }
+/// # fn throwaway(_: impl Fn(kobold::reexport::web_sys::Event)) {}
+/// # throwaway(increment);
+/// # throwaway(decrement);
+/// # }
+/// ```
+/// Desugars into:
+///
+/// ```
+/// # use kobold::{bind, stateful::Hook};
+/// # fn test(count: &Hook<i32>) {
+/// let increment = count.bind(move |count, _| *count += 1);
+/// let decrement = count.bind(move |count, _| *count -= 1);
+/// # fn throwaway(_: impl Fn(kobold::reexport::web_sys::Event)) {}
+/// # throwaway(increment);
+/// # throwaway(decrement);
+/// # }
+/// ```
 #[macro_export]
 macro_rules! bind {
     ($hook:ident: $(let $v:ident = move |$e:tt $(: $e_ty:ty)?| $body:expr;)+) => {

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -295,8 +295,10 @@ pub mod branching;
 pub mod dom;
 pub mod event;
 pub mod list;
-pub mod stateful;
 pub mod util;
+
+#[cfg(feature = "stateful")]
+pub mod stateful;
 
 /// The prelude module with most commonly used types.
 ///
@@ -307,12 +309,12 @@ pub mod util;
 pub mod prelude {
     pub use crate::event::{Event, KeyboardEvent, MouseEvent};
     pub use crate::list::ListIteratorExt as _;
-    pub use crate::stateful::{stateful, Hook, IntoState, Signal, Then};
-    pub use crate::{bind, class};
-    // pub use crate::stateful::{ShouldRender, WeakHook};
-    // pub use crate::stateful::{stateful, Hook, IntoState, ShouldRender, WeakHook};
     pub use crate::value::{StrExt as _, Stringify as _};
+    pub use crate::{bind, class};
     pub use crate::{component, view, View};
+
+    #[cfg(feature = "stateful")]
+    pub use crate::stateful::{stateful, Hook, IntoState, Signal, Then};
 }
 
 use dom::Element;

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -62,9 +62,9 @@
 //! You can even use [rust-analyzer](https://rust-analyzer.github.io/) to refactor component or field names,
 //! and it will change the invocations inside the macros for you.
 //!
-//! ### Stateful components
+//! ### Stateful
 //!
-//! The [`stateful`](stateful::stateful) function can be used to create components that own and manipulate
+//! The [`stateful`](stateful::stateful) function can be used to create views that own and manipulate
 //! their state:
 //!
 //! ```no_run

--- a/crates/kobold/src/list.rs
+++ b/crates/kobold/src/list.rs
@@ -3,7 +3,7 @@
 use web_sys::Node;
 
 use crate::dom::Fragment;
-use crate::{Element, View, Mountable};
+use crate::{Element, Mountable, View};
 
 /// Wrapper type that implements `View` for iterators. Use the [`list`](ListIteratorExt::list)
 /// method on the iterator to create one.

--- a/crates/kobold/src/list.rs
+++ b/crates/kobold/src/list.rs
@@ -3,9 +3,9 @@
 use web_sys::Node;
 
 use crate::dom::Fragment;
-use crate::{Element, Html, Mountable};
+use crate::{Element, View, Mountable};
 
-/// Wrapper type that implements `Html` for iterators. Use the [`list`](ListIteratorExt::list)
+/// Wrapper type that implements `View` for iterators. Use the [`list`](ListIteratorExt::list)
 /// method on the iterator to create one.
 #[repr(transparent)]
 pub struct List<T>(T);
@@ -32,12 +32,12 @@ pub trait ListIteratorExt: Iterator + Sized {
 
 impl<T: Iterator> ListIteratorExt for T {}
 
-impl<T> Html for List<T>
+impl<T> View for List<T>
 where
     T: IntoIterator,
-    <T as IntoIterator>::Item: Html,
+    <T as IntoIterator>::Item: View,
 {
-    type Product = ListProduct<<T::Item as Html>::Product>;
+    type Product = ListProduct<<T::Item as View>::Product>;
 
     fn build(self) -> Self::Product {
         let iter = self.0.into_iter();
@@ -95,7 +95,7 @@ where
     }
 }
 
-impl<H: Html> Html for Vec<H> {
+impl<H: View> View for Vec<H> {
     type Product = ListProduct<H::Product>;
 
     fn build(self) -> Self::Product {
@@ -107,11 +107,11 @@ impl<H: Html> Html for Vec<H> {
     }
 }
 
-impl<'a, H> Html for &'a [H]
+impl<'a, H> View for &'a [H]
 where
-    &'a H: Html,
+    &'a H: View,
 {
-    type Product = ListProduct<<&'a H as Html>::Product>;
+    type Product = ListProduct<<&'a H as View>::Product>;
 
     fn build(self) -> Self::Product {
         List(self).build()
@@ -122,7 +122,7 @@ where
     }
 }
 
-impl<H: Html, const N: usize> Html for [H; N] {
+impl<H: View, const N: usize> View for [H; N] {
     type Product = ListProduct<H::Product>;
 
     fn build(self) -> Self::Product {

--- a/crates/kobold/src/stateful.rs
+++ b/crates/kobold/src/stateful.rs
@@ -15,7 +15,7 @@ use std::rc::{Rc, Weak};
 use web_sys::Node;
 
 use crate::util::WithCell;
-use crate::{dom::Element, Html, Mountable};
+use crate::{dom::Element, View, Mountable};
 
 mod hook;
 mod should_render;
@@ -76,7 +76,7 @@ pub fn stateful<'a, S, F, H>(
 where
     S: IntoState,
     F: Fn(&'a Hook<S::State>) -> H + 'static,
-    H: Html + 'a,
+    H: View + 'a,
 {
     let render = move |hook: *const Hook<S::State>| render(unsafe { &*hook });
     Stateful { state, render }
@@ -99,11 +99,11 @@ impl<T> WeakRef<T> {
     }
 }
 
-impl<S, F, H> Html for Stateful<S, F>
+impl<S, F, H> View for Stateful<S, F>
 where
     S: IntoState,
     F: Fn(*const Hook<S::State>) -> H + 'static,
-    H: Html,
+    H: View,
 {
     type Product = StatefulProduct<S::State>;
 
@@ -172,11 +172,11 @@ pub struct Once<S, R, F> {
     handler: F,
 }
 
-impl<S, R, F> Html for Once<S, R, F>
+impl<S, R, F> View for Once<S, R, F>
 where
     S: IntoState,
     F: FnOnce(Signal<S::State>),
-    Stateful<S, R>: Html<Product = StatefulProduct<S::State>>,
+    Stateful<S, R>: View<Product = StatefulProduct<S::State>>,
 {
     type Product = StatefulProduct<S::State>;
 

--- a/crates/kobold/src/stateful.rs
+++ b/crates/kobold/src/stateful.rs
@@ -1,13 +1,11 @@
-//! # Utilities for building stateful components
+//! # Utilities for building stateful views
 //!
-//! **Kobold** uses _functional components_ that are _transient_, meaning they can include
-//! borrowed values and are discarded on each render call. **Kobold** doesn't
-//! allocate any memory on the heap for its simple components, and there is no way to update them
-//! short of the parent component re-rendering them.
+//! **Kobold** doesn't allocate any memory on the heap for its simple components, and there
+//! is no way to update them short of the parent view re-rendering them.
 //!
-//! However an app built entirely from such components wouldn't be very useful, as all it
+//! However a fully functional app like that wouldn't be very useful, as all it
 //! could ever do is render itself once. To get around this the [`stateful`](stateful) function can
-//! be used to give a component ownership over some arbitrary mutable state.
+//! be used to create views that have ownership over some arbitrary mutable state.
 //!
 use std::cell::{Cell, UnsafeCell};
 use std::mem::{ManuallyDrop, MaybeUninit};

--- a/crates/kobold/src/stateful/hook.rs
+++ b/crates/kobold/src/stateful/hook.rs
@@ -1,8 +1,7 @@
 use std::ops::Deref;
 use std::rc::Weak;
 
-use crate::stateful::{Inner, ShouldRender, WeakRef};
-use crate::util::WithCell;
+use crate::stateful::{Inner, ShouldRender, WeakRef, WithCell};
 use crate::View;
 
 /// A hook to some state `S`. A reference to `Hook` is obtained by using the [`stateful`](crate::stateful::stateful)

--- a/crates/kobold/src/stateful/hook.rs
+++ b/crates/kobold/src/stateful/hook.rs
@@ -3,7 +3,7 @@ use std::rc::Weak;
 
 use crate::stateful::{Inner, ShouldRender, WeakRef};
 use crate::util::WithCell;
-use crate::Html;
+use crate::View;
 
 /// A hook to some state `S`. A reference to `Hook` is obtained by using the [`stateful`](crate::stateful::stateful)
 /// function.
@@ -97,11 +97,11 @@ impl<S> Deref for Hook<S> {
     }
 }
 
-impl<'a, H> Html for &'a Hook<H>
+impl<'a, H> View for &'a Hook<H>
 where
-    &'a H: Html + 'a,
+    &'a H: View + 'a,
 {
-    type Product = <&'a H as Html>::Product;
+    type Product = <&'a H as View>::Product;
 
     fn build(self) -> Self::Product {
         (**self).build()

--- a/crates/kobold/src/stateful/should_render.rs
+++ b/crates/kobold/src/stateful/should_render.rs
@@ -1,8 +1,8 @@
 /// Describes whether or not a component should be rendered after state changes.
 /// For uses see:
 ///
-/// * [`Hook::bind`](crate::state::Hook::bind)
-/// * [`IntoState::update`](crate::state::IntoState::update)
+/// * [`Hook::bind`](crate::stateful::Hook::bind)
+/// * [`IntoState::update`](crate::stateful::IntoState::update)
 pub trait ShouldRender {
     fn should_render(self) -> bool;
 }
@@ -14,11 +14,11 @@ impl ShouldRender for () {
     }
 }
 
-/// Describes whether or not a component should be rendered after state changes.
-/// For uses see:
+/// An enum that implements the [`ShouldRender`](ShouldRender) trait.
+/// See:
 ///
-/// * [`Hook::bind`](Hook::bind)
-/// * [`IntoState::update`](IntoState::update)
+/// * [`Hook::bind`](crate::stateful::Hook::bind)
+/// * [`IntoState::update`](crate::stateful::IntoState::update)
 pub enum Then {
     /// This is a silent update
     Stop,

--- a/crates/kobold/src/util.rs
+++ b/crates/kobold/src/util.rs
@@ -4,11 +4,11 @@ use wasm_bindgen::prelude::*;
 use web_sys::Node;
 
 use crate::dom::Element;
-use crate::Html;
+use crate::View;
 
 pub struct Static<F>(pub F);
 
-impl<F> Html for Static<F>
+impl<F> View for Static<F>
 where
     F: Fn() -> Node,
 {

--- a/crates/kobold/src/util.rs
+++ b/crates/kobold/src/util.rs
@@ -1,5 +1,3 @@
-use std::cell::{Cell, UnsafeCell};
-
 use wasm_bindgen::prelude::*;
 use web_sys::Node;
 
@@ -19,33 +17,6 @@ where
     }
 
     fn update(self, _: &mut Element) {}
-}
-
-pub(crate) struct WithCell<T> {
-    borrowed: Cell<bool>,
-    data: UnsafeCell<T>,
-}
-
-impl<T> WithCell<T> {
-    pub(crate) fn new(data: T) -> Self {
-        WithCell {
-            borrowed: Cell::new(false),
-            data: UnsafeCell::new(data),
-        }
-    }
-
-    pub(crate) fn with<F>(&self, mutator: F)
-    where
-        F: FnOnce(&mut T),
-    {
-        if self.borrowed.get() {
-            return;
-        }
-
-        self.borrowed.set(true);
-        mutator(unsafe { &mut *self.data.get() });
-        self.borrowed.set(false);
-    }
 }
 
 #[wasm_bindgen(module = "/js/util.js")]

--- a/crates/kobold/src/value.rs
+++ b/crates/kobold/src/value.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use web_sys::Text;
 
 use crate::prelude::{IntoState, Then};
-use crate::{Element, Html, Mountable};
+use crate::{Element, View, Mountable};
 
 pub struct ValueProduct<T> {
     value: T,
@@ -18,7 +18,7 @@ impl<T: 'static> Mountable for ValueProduct<T> {
     }
 }
 
-impl Html for String {
+impl View for String {
     type Product = ValueProduct<String>;
 
     fn build(self) -> Self::Product {
@@ -35,7 +35,7 @@ impl Html for String {
     }
 }
 
-impl Html for &String {
+impl View for &String {
     type Product = ValueProduct<String>;
 
     fn build(self) -> Self::Product {
@@ -43,7 +43,7 @@ impl Html for &String {
     }
 
     fn update(self, p: &mut Self::Product) {
-        Html::update(self.as_str(), p)
+        View::update(self.as_str(), p)
     }
 }
 
@@ -71,7 +71,7 @@ impl<T> Deref for NoDiff<T> {
     }
 }
 
-impl<T: Stringify> Html for NoDiff<T> {
+impl<T: Stringify> View for NoDiff<T> {
     type Product = Element;
 
     fn build(self) -> Self::Product {
@@ -124,7 +124,7 @@ macro_rules! stringify_float {
 macro_rules! impl_stringify {
     ($($t:ty),*) => {
         $(
-            impl Html for $t {
+            impl View for $t {
                 type Product = ValueProduct<$t>;
 
                 fn build(self) -> Self::Product {
@@ -142,7 +142,7 @@ macro_rules! impl_stringify {
                 }
             }
 
-            impl Html for &$t {
+            impl View for &$t {
                 type Product = ValueProduct<$t>;
 
                 fn build(self) -> Self::Product {
@@ -150,7 +150,7 @@ macro_rules! impl_stringify {
                 }
 
                 fn update(self, p: &mut Self::Product) {
-                    Html::update(*self, p);
+                    View::update(*self, p);
                 }
             }
 
@@ -174,7 +174,7 @@ macro_rules! impl_stringify {
     };
 }
 
-impl Html for &str {
+impl View for &str {
     type Product = ValueProduct<String>;
 
     fn build(self) -> Self::Product {
@@ -194,15 +194,15 @@ impl Html for &str {
     }
 }
 
-impl Html for &&str {
+impl View for &&str {
     type Product = ValueProduct<String>;
 
     fn build(self) -> Self::Product {
-        Html::build(*self)
+        View::build(*self)
     }
 
     fn update(self, p: &mut Self::Product) {
-        Html::update(*self, p);
+        View::update(*self, p);
     }
 }
 
@@ -244,7 +244,7 @@ impl Deref for FastDiff<'_> {
     }
 }
 
-impl Html for FastDiff<'_> {
+impl View for FastDiff<'_> {
     type Product = ValueProduct<usize>;
 
     fn build(self) -> Self::Product {

--- a/crates/kobold/src/value.rs
+++ b/crates/kobold/src/value.rs
@@ -2,8 +2,9 @@ use std::ops::Deref;
 
 use web_sys::Text;
 
-use crate::prelude::{IntoState, Then};
-use crate::{Element, View, Mountable};
+#[cfg(feature = "stateful")]
+use crate::stateful::{IntoState, Then};
+use crate::{Element, Mountable, View};
 
 pub struct ValueProduct<T> {
     value: T,
@@ -206,6 +207,7 @@ impl View for &&str {
     }
 }
 
+#[cfg(feature = "stateful")]
 impl IntoState for &str {
     type State = String;
 

--- a/crates/kobold_macros/src/branching/parse.rs
+++ b/crates/kobold_macros/src/branching/parse.rs
@@ -50,7 +50,7 @@ impl CodeBuilder {
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Token {
     /// The `html` identifier
-    Html,
+    View,
     /// The `if` keyword
     If,
     /// The `else` keyword
@@ -66,7 +66,7 @@ enum Token {
 impl Token {
     fn from_str(ident: &str) -> Option<Token> {
         match ident {
-            "html" => Some(Token::Html),
+            "view" => Some(Token::View),
             "if" => Some(Token::If),
             "else" => Some(Token::Else),
             "match" => Some(Token::Match),
@@ -139,7 +139,7 @@ fn parse_code(stream: &mut ParseStream, scope: Branches) -> Result<Vec<Code>, Pa
         };
 
         match token {
-            Token::Html => {
+            Token::View => {
                 let mut maybe_html = ArrayVec::<_, 3>::new();
 
                 maybe_html.push(tt);

--- a/crates/kobold_macros/src/dom.rs
+++ b/crates/kobold_macros/src/dom.rs
@@ -20,7 +20,7 @@ pub fn parse(tokens: TokenStream) -> Result<Vec<Node>, ParseError> {
     }
 
     if nodes.is_empty() {
-        return Err(ParseError::new("Empty html! invocation", Span::call_site()));
+        return Err(ParseError::new("Empty view! invocation", Span::call_site()));
     }
 
     Ok(nodes)

--- a/crates/kobold_macros/src/gen.rs
+++ b/crates/kobold_macros/src/gen.rs
@@ -58,7 +58,7 @@ impl Generator {
     fn add_expression(&mut self, value: TokenStream) -> Short {
         let name = self.names.next();
 
-        self.out.fields.push(Field::Html { name, value });
+        self.out.fields.push(Field::View { name, value });
 
         name
     }

--- a/crates/kobold_macros/src/gen/component.rs
+++ b/crates/kobold_macros/src/gen/component.rs
@@ -52,7 +52,7 @@ impl IntoGenerator for Component {
         let name = gen.names.next();
         let value = self.into_expression();
 
-        gen.out.fields.push(Field::Html { name, value });
+        gen.out.fields.push(Field::View { name, value });
 
         DomNode::Variable(name)
     }

--- a/crates/kobold_macros/src/gen/transient.rs
+++ b/crates/kobold_macros/src/gen/transient.rs
@@ -54,7 +54,7 @@ impl Tokenize for Transient {
 
         if self.els.is_empty() {
             return match self.fields.remove(0) {
-                Field::Html { value, .. } | Field::Attribute { value, .. } => {
+                Field::View { value, .. } | Field::Attribute { value, .. } => {
                     value.tokenize_in(stream)
                 }
             };
@@ -143,7 +143,7 @@ impl Tokenize for Transient {
                         {declare}\
                     }}\
                     \
-                    impl<{abi_lifetime}{generics}> ::kobold::Html for Transient<{generics}>\
+                    impl<{abi_lifetime}{generics}> ::kobold::View for Transient<{generics}>\
                     where \
                         {bounds}\
                     {{\
@@ -254,7 +254,7 @@ impl Tokenize for JsArgument {
 }
 
 pub enum Field {
-    Html {
+    View {
         name: Short,
         value: TokenStream,
     },
@@ -285,8 +285,8 @@ impl Deref for Abi {
 impl Debug for Field {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Field::Html { name, value } => {
-                write!(f, "{name} <Html>: {value}")
+            Field::View { name, value } => {
+                write!(f, "{name} <View>: {value}")
             }
             Field::Attribute {
                 name,
@@ -315,7 +315,7 @@ impl Field {
 
     fn name_value(&self) -> (&Short, &TokenStream) {
         match self {
-            Field::Html { name, value } | Field::Attribute { name, value, .. } => (name, value),
+            Field::View { name, value } | Field::Attribute { name, value, .. } => (name, value),
         }
     }
 
@@ -329,11 +329,11 @@ impl Field {
 
     fn bounds(&self, buf: &mut String) {
         match self {
-            Field::Html { name, .. } => {
+            Field::View { name, .. } => {
                 let mut typ = *name;
                 typ.make_ascii_uppercase();
 
-                let _ = write!(buf, "{typ}: ::kobold::Html,");
+                let _ = write!(buf, "{typ}: ::kobold::View,");
             }
             Field::Attribute { name, abi, .. } => {
                 let mut typ = *name;
@@ -355,7 +355,7 @@ impl Field {
 
     fn build(&self, buf: &mut String) {
         match self {
-            Field::Html { name, .. } => {
+            Field::View { name, .. } => {
                 let _ = write!(buf, "let {name} = self.{name}.build();");
             }
             Field::Attribute { name, .. } => {
@@ -366,7 +366,7 @@ impl Field {
 
     fn var(&self, buf: &mut String) {
         match self {
-            Field::Html { name, .. } => {
+            Field::View { name, .. } => {
                 let _ = write!(buf, "{name},");
             }
             Field::Attribute { name, .. } => {
@@ -377,7 +377,7 @@ impl Field {
 
     fn update(&self, buf: &mut String) {
         match self {
-            Field::Html { name, .. } => {
+            Field::View { name, .. } => {
                 let _ = write!(buf, "self.{name}.update(&mut p.{name});");
             }
             Field::Attribute { name, el, .. } => {

--- a/crates/kobold_macros/src/lib.rs
+++ b/crates/kobold_macros/src/lib.rs
@@ -43,7 +43,7 @@ pub fn component(args: TokenStream, input: TokenStream) -> TokenStream {
 
 #[allow(clippy::let_and_return)]
 #[proc_macro]
-pub fn html(body: TokenStream) -> TokenStream {
+pub fn view(body: TokenStream) -> TokenStream {
     let nodes = unwrap_err!(dom::parse(body));
 
     // panic!("{nodes:#?}");

--- a/crates/kobold_qr/src/lib.rs
+++ b/crates/kobold_qr/src/lib.rs
@@ -5,12 +5,12 @@ use fast_qr::qr::QRBuilder;
 use web_sys::CanvasRenderingContext2d;
 
 #[component]
-pub fn KoboldQR(data: &str) -> impl Html {
+pub fn KoboldQR(data: &str) -> impl View {
     let qr = QRBuilder::new(data).build().ok()?;
     let size = qr.size * 8;
 
     Some(
-        html! {
+        view! {
             <canvas width={size} height={size} style="width: 200px; height: 200px;" />
         }
         .on_render(move |canvas| {

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -1,14 +1,14 @@
 use kobold::prelude::*;
 
 #[component]
-fn Counter() -> impl Html {
+fn Counter() -> impl View {
     stateful(0_u32, |count| {
         bind! { count:
             let onclick = move |_| *count += 1;
             let reset = move |_| *count = 0;
         }
 
-        html! {
+        view! {
             <p>
                 <ShowCount count={count.get()} />
 
@@ -21,18 +21,18 @@ fn Counter() -> impl Html {
 }
 
 #[component(auto_branch)]
-fn ShowCount(count: u32) -> impl Html {
+fn ShowCount(count: u32) -> impl View {
     let count = match count {
-        0 => html! { "zero times." },
-        1 => html! { "once." },
-        n => html! { { n }" times." },
+        0 => view! { "zero times." },
+        1 => view! { "once." },
+        n => view! { { n }" times." },
     };
 
-    html! { <h3>"You've clicked the button "{ count }</h3> }
+    view! { <h3>"You've clicked the button "{ count }</h3> }
 }
 
 fn main() {
-    kobold::start(html! {
+    kobold::start(view! {
         <Counter />
     });
 }

--- a/examples/csv_editor/src/main.rs
+++ b/examples/csv_editor/src/main.rs
@@ -8,7 +8,7 @@ mod state;
 use state::{Editing, State, Text};
 
 #[component]
-fn Editor() -> impl Html {
+fn Editor() -> impl View {
     stateful(State::mock, |state| {
         let onload = {
             let signal = state.signal();
@@ -43,23 +43,23 @@ fn Editor() -> impl Html {
             };
         }
 
-        html! {
+        view! {
             <input type="file" accept="text/csv" onchange={onload} />
             <h1>{ state.name.fast_diff() }</h1>
             <table {onkeydown}>
                 <thead>
                     <tr>
                     {
-                        state.columns().map(|col| html! { <Head {col} {state} /> }).list()
+                        state.columns().map(|col| view! { <Head {col} {state} /> }).list()
                     }
                     </tr>
                 </thead>
                 <tbody>
                 {
-                    state.rows().map(move |row| html! {
+                    state.rows().map(move |row| view! {
                         <tr>
                         {
-                            state.columns().map(move |col| html! {
+                            state.columns().map(move |col| view! {
                                 <Cell {col} {row} {state} />
                             })
                             .list()
@@ -75,7 +75,7 @@ fn Editor() -> impl Html {
 }
 
 #[component(auto_branch)]
-fn Head(col: usize, state: &Hook<State>) -> impl Html + '_ {
+fn Head(col: usize, state: &Hook<State>) -> impl View + '_ {
     let value = state.source.get_text(&state.columns[col]);
 
     if state.editing == (Editing::Column { col }) {
@@ -84,7 +84,7 @@ fn Head(col: usize, state: &Hook<State>) -> impl Html + '_ {
             state.editing = Editing::None;
         });
 
-        html! {
+        view! {
             <th.edit>
                 { value.fast_diff() }
                 <input.edit.edit-head {onchange} value={ value.fast_diff() } />
@@ -93,12 +93,12 @@ fn Head(col: usize, state: &Hook<State>) -> impl Html + '_ {
     } else {
         let ondblclick = state.bind(move |s, _| s.editing = Editing::Column { col });
 
-        html! { <th {ondblclick}>{ value.fast_diff() }</th> }
+        view! { <th {ondblclick}>{ value.fast_diff() }</th> }
     }
 }
 
 #[component(auto_branch)]
-fn Cell(col: usize, row: usize, state: &Hook<State>) -> impl Html + '_ {
+fn Cell(col: usize, row: usize, state: &Hook<State>) -> impl View + '_ {
     let value = state.source.get_text(&state.rows[row][col]);
 
     if state.editing == (Editing::Cell { row, col }) {
@@ -107,7 +107,7 @@ fn Cell(col: usize, row: usize, state: &Hook<State>) -> impl Html + '_ {
             state.editing = Editing::None;
         });
 
-        html! {
+        view! {
             <td.edit>
                 { value.fast_diff() }
                 <input.edit {onchange} value={ value.fast_diff() } />
@@ -116,12 +116,12 @@ fn Cell(col: usize, row: usize, state: &Hook<State>) -> impl Html + '_ {
     } else {
         let ondblclick = state.bind(move |s, _| s.editing = Editing::Cell { row, col });
 
-        html! { <td {ondblclick}>{ value.fast_diff() }</td> }
+        view! { <td {ondblclick}>{ value.fast_diff() }</td> }
     }
 }
 
 fn main() {
-    kobold::start(html! {
+    kobold::start(view! {
         <Editor />
     });
 }

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -1,14 +1,14 @@
 use kobold::prelude::*;
 
 #[component]
-fn Hello(name: &str) -> impl Html + '_ {
-    html! {
+fn Hello(name: &str) -> impl View + '_ {
+    view! {
         <h1>"Hello "{ name }"!"</h1>
     }
 }
 
 fn main() {
-    kobold::start(html! {
+    kobold::start(view! {
         <Hello name="Kobold" />
     });
 }

--- a/examples/interval/src/main.rs
+++ b/examples/interval/src/main.rs
@@ -2,13 +2,13 @@ use gloo_timers::callback::Interval;
 use kobold::prelude::*;
 
 #[component]
-fn Elapsed() -> impl Html {
+fn Elapsed() -> impl View {
     stateful(0_u32, |seconds| {
         bind! { seconds:
             let onclick = move |_| *seconds = 0;
         }
 
-        html! {
+        view! {
             <p>
                 "Elapsed seconds: "{ seconds }" "
                 // `{onclick}` here is shorthand for `onclick={onclick}`
@@ -25,7 +25,7 @@ fn Elapsed() -> impl Html {
 }
 
 fn main() {
-    kobold::start(html! {
+    kobold::start(view! {
         <Elapsed />
     });
 }

--- a/examples/list/src/main.rs
+++ b/examples/list/src/main.rs
@@ -1,14 +1,14 @@
 use kobold::prelude::*;
 
 #[component]
-fn ListExample(count: u32) -> impl Html {
+fn ListExample(count: u32) -> impl View {
     stateful(count, |count| {
         bind! { count:
             let dec = move |_| *count = count.saturating_sub(1);
             let inc = move |_| *count += 1;
         }
 
-        html! {
+        view! {
             <div>
                 <h1 class="Greeter">"List example"</h1>
                 <p>
@@ -26,7 +26,7 @@ fn ListExample(count: u32) -> impl Html {
                     //
                     // `{n}` is just shorthand for `n={n}`.
                     (1..=count.get())
-                        .map(|n| html! { <ListItem {n} /> })
+                        .map(|n| view! { <ListItem {n} /> })
                         .list()
                 }
                 </ul>
@@ -36,12 +36,12 @@ fn ListExample(count: u32) -> impl Html {
 }
 
 #[component]
-fn ListItem(n: u32) -> impl Html {
-    html! { <li>"Item #"{ n }</li> }
+fn ListItem(n: u32) -> impl View {
+    view! { <li>"Item #"{ n }</li> }
 }
 
 fn main() {
-    kobold::start(html! {
+    kobold::start(view! {
         <ListExample count={2} />
     });
 }

--- a/examples/qrcode/src/main.rs
+++ b/examples/qrcode/src/main.rs
@@ -3,7 +3,7 @@ use kobold::reexport::web_sys::HtmlTextAreaElement;
 use kobold_qr::KoboldQR;
 
 #[component]
-fn QRExample() -> impl Html {
+fn QRExample() -> impl View {
     stateful("Enter something", |data| {
         bind! {
             data:
@@ -11,7 +11,7 @@ fn QRExample() -> impl Html {
             let onkeyup = move |event: KeyboardEvent<HtmlTextAreaElement>| *data = event.target().value();
         }
 
-        html! {
+        view! {
             <h1>"QR code example"</h1>
             <KoboldQR data={data.as_str()} />
             <textarea {onkeyup}>
@@ -22,7 +22,7 @@ fn QRExample() -> impl Html {
 }
 
 fn main() {
-    kobold::start(html! {
+    kobold::start(view! {
         <QRExample />
     });
 }

--- a/examples/stateful/src/main.rs
+++ b/examples/stateful/src/main.rs
@@ -15,7 +15,7 @@ impl State {
 }
 
 #[component]
-fn App() -> impl Html {
+fn App() -> impl View {
     stateful(State::new, |state| {
         bind! { state:
             // Since we work with a state that owns a `String`,
@@ -34,7 +34,7 @@ fn App() -> impl Html {
             let adult = move |_| state.age = 0;
         }
 
-        html! {
+        view! {
             <div>
                 // Render can borrow `name` from state, no need for clones
                 <h1>{ &state.name }" is "{ state.age }" years old."</h1>
@@ -49,7 +49,7 @@ fn App() -> impl Html {
 }
 
 fn main() {
-    kobold::start(html! {
+    kobold::start(view! {
         <App />
     });
 }

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -8,7 +8,7 @@ use filter::Filter;
 use state::*;
 
 #[component]
-fn App() -> impl Html {
+fn App() -> impl View {
     stateful(State::default, |state| {
         let hidden = class!("hidden" if state.entries.is_empty());
 
@@ -19,7 +19,7 @@ fn App() -> impl Html {
             let clear = move |_| state.clear();
         }
 
-        html! {
+        view! {
             <div .todomvc-wrapper>
                 <section .todoapp>
                     <header .header>
@@ -32,7 +32,7 @@ fn App() -> impl Html {
                             {
                                 state
                                     .filtered_entries()
-                                    .map(move |(idx, entry)| html! { <EntryView {idx} {entry} {state} /> })
+                                    .map(move |(idx, entry)| view! { <EntryView {idx} {entry} {state} /> })
                                     .list()
                             }
                         </ul>
@@ -69,7 +69,7 @@ fn App() -> impl Html {
 }
 
 #[component]
-fn EntryInput(state: &Hook<State>) -> impl Html + '_ {
+fn EntryInput(state: &Hook<State>) -> impl View + '_ {
     bind! { state:
         let onchange = move |event: Event<InputElement>| {
             let input = event.target();
@@ -80,25 +80,25 @@ fn EntryInput(state: &Hook<State>) -> impl Html + '_ {
         };
     }
 
-    html! {
+    view! {
         <input.new-todo placeholder="What needs to be done?" {onchange} />
     }
 }
 
 #[component]
-fn ToggleAll(active_count: usize, state: &Hook<State>) -> impl Html + '_ {
+fn ToggleAll(active_count: usize, state: &Hook<State>) -> impl View + '_ {
     bind! { state:
         let onclick = move |_| state.set_all(active_count != 0);
     }
 
-    html! {
+    view! {
         <input #toggle-all.toggle-all type="checkbox" checked={active_count == 0} onclick={onclick} />
         <label for="toggle-all" />
     }
 }
 
 #[component]
-fn EntryView<'a>(idx: usize, entry: &'a Entry, state: &'a Hook<State>) -> impl Html + 'a {
+fn EntryView<'a>(idx: usize, entry: &'a Entry, state: &'a Hook<State>) -> impl View + 'a {
     let input = entry.editing.then(move || {
         bind! { state:
             let onkeypress = move |event: KeyboardEvent<InputElement>| {
@@ -118,7 +118,7 @@ fn EntryView<'a>(idx: usize, entry: &'a Entry, state: &'a Hook<State>) -> impl H
             let _ = event.target().focus();
         };
 
-        html! {
+        view! {
             <input .edit
                 type="text"
                 value={entry.description.fast_diff()}
@@ -138,7 +138,7 @@ fn EntryView<'a>(idx: usize, entry: &'a Entry, state: &'a Hook<State>) -> impl H
     let editing = class!("editing" if entry.editing);
     let completed = class!("completed" if entry.completed);
 
-    html! {
+    view! {
         <li .todo.{editing}.{completed}>
             <div .view>
                 <input .toggle type="checkbox" checked={entry.completed} {onchange} />
@@ -153,7 +153,7 @@ fn EntryView<'a>(idx: usize, entry: &'a Entry, state: &'a Hook<State>) -> impl H
 }
 
 #[component]
-fn FilterView(filter: Filter, state: &Hook<State>) -> impl Html + '_ {
+fn FilterView(filter: Filter, state: &Hook<State>) -> impl View + '_ {
     let selected = state.filter;
 
     let class = class!("selected" if selected == filter);
@@ -162,7 +162,7 @@ fn FilterView(filter: Filter, state: &Hook<State>) -> impl Html + '_ {
         let onclick = move |_| state.filter = filter;
     }
 
-    html! {
+    view! {
         <li>
             <a {class} {href} {onclick}>{ filter.label().no_diff() }</a>
         </li>
@@ -170,7 +170,7 @@ fn FilterView(filter: Filter, state: &Hook<State>) -> impl Html + '_ {
 }
 
 fn main() {
-    kobold::start(html! {
+    kobold::start(view! {
         <App />
     });
 }


### PR DESCRIPTION
1. Renames `Html` to `View`.
2. Renames `html!` to `view!`.
3. The whole `stateful` module is now behind (enabled by default) feature flag.