### PR TITLE
Coerce floats, bools, and ints to text by passing them directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,6 @@ dependencies = [
  "console_error_panic_hook",
  "itoa",
  "kobold_macros",
- "ryu",
  "wasm-bindgen",
  "web-sys",
 ]

--- a/crates/kobold/Cargo.toml
+++ b/crates/kobold/Cargo.toml
@@ -17,8 +17,7 @@ stateful = []
 
 [dependencies]
 wasm-bindgen = "0.2.84"
-itoa = "1.0.1"
-ryu = "1.0.12"
+itoa = "1.0.6"
 kobold_macros = { version = "0.5.0", path = "../kobold_macros" }
 console_error_panic_hook = "0.1.7"
 

--- a/crates/kobold/js/util.js
+++ b/crates/kobold/js/util.js
@@ -37,16 +37,15 @@ export function __kobold_fragment_drop(f)
 	delete f.$end;
 }
 
-export function __kobold_update_text(n,t) { n.textContent = t; }
+export function __kobold_set_text(n,t) { n.textContent = t; }
+export function __kobold_set_attr(a,v) { a.value = v; }
 
-export function __kobold_attr(n,v) { let a = document.createAttribute(n); a.value = v; return a; }
-export function __kobold_attr_class(v) { let a = document.createAttribute('class'); a.value = v; return a; }
-export function __kobold_attr_style(v) { let a = document.createAttribute('style'); a.value = v; return a; }
-export function __kobold_attr_set(n,k,v) { n.setAttribute(k, v); }
-export function __kobold_attr_update(n,v) { n.value = v; }
+export function __kobold_attr_href() { return document.createAttribute("href"); }
+export function __kobold_attr_style() { return document.createAttribute("style"); }
+export function __kobold_attr_value() { return document.createAttribute("value"); }
 
-export function __kobold_attr_checked_set(n,v) { if (n.checked !== v) n.checked = v; }
-export function __kobold_class_set(n,v) { n.className = v; }
-export function __kobold_class_add(n,v) { n.classList.add(v); }
-export function __kobold_class_remove(n,v) { n.classList.remove(v); }
-export function __kobold_class_replace(n,o,v) { n.classList.replace(o,v); }
+export function __kobold_set_checked(n,v) { if (n.checked !== v) n.checked = v; }
+export function __kobold_set_class_name(n,v) { n.className = v; }
+export function __kobold_add_class(n,v) { n.classList.add(v); }
+export function __kobold_remove_class(n,v) { n.classList.remove(v); }
+export function __kobold_replace_class(n,o,v) { n.classList.replace(o,v); }

--- a/crates/kobold/js/util.js
+++ b/crates/kobold/js/util.js
@@ -1,7 +1,5 @@
 const fragmentDecorators = new WeakMap();
 
-export function __kobold_start(n) { document.body.appendChild(n); }
-
 export function __kobold_append(n,c) { n.appendChild(c); }
 export function __kobold_before(n,i) { n.before(i); }
 export function __kobold_unmount(n) { n.remove(); }
@@ -38,10 +36,8 @@ export function __kobold_fragment_drop(f)
 	delete f.$begin;
 	delete f.$end;
 }
-export function __kobold_text_node(t) { return document.createTextNode(t); }
-export function __kobold_text_node_coerce(t) { return document.createTextNode(t.toString()); }
+
 export function __kobold_update_text(n,t) { n.textContent = t; }
-export function __kobold_update_text_coerce(n,t) { n.textContent = t.toString(); }
 
 export function __kobold_attr(n,v) { let a = document.createAttribute(n); a.value = v; return a; }
 export function __kobold_attr_class(v) { let a = document.createAttribute('class'); a.value = v; return a; }

--- a/crates/kobold/js/util.js
+++ b/crates/kobold/js/util.js
@@ -39,7 +39,9 @@ export function __kobold_fragment_drop(f)
 	delete f.$end;
 }
 export function __kobold_text_node(t) { return document.createTextNode(t); }
+export function __kobold_text_node_coerce(t) { return document.createTextNode(t.toString()); }
 export function __kobold_update_text(n,t) { n.textContent = t; }
+export function __kobold_update_text_coerce(n,t) { n.textContent = t.toString(); }
 
 export function __kobold_attr(n,v) { let a = document.createAttribute(n); a.value = v; return a; }
 export function __kobold_attr_class(v) { let a = document.createAttribute('class'); a.value = v; return a; }

--- a/crates/kobold/src/attribute.rs
+++ b/crates/kobold/src/attribute.rs
@@ -2,9 +2,9 @@
 use wasm_bindgen::convert::IntoWasmAbi;
 use wasm_bindgen::JsValue;
 
+use crate::dom::{LargeInt, NoDiff};
 use crate::util;
-use crate::dom::NoDiff;
-use crate::value::{FastDiff, Stringify};
+use crate::value::FastDiff;
 use crate::{Element, Mountable, View};
 
 pub trait Attribute {
@@ -81,7 +81,7 @@ impl View for AttributeNode<&String> {
 
 impl<S> View for AttributeNode<S>
 where
-    S: Stringify + Eq + Copy + 'static,
+    S: LargeInt + Eq + Copy + 'static,
 {
     type Product = AttributeNodeProduct<S>;
 

--- a/crates/kobold/src/attribute.rs
+++ b/crates/kobold/src/attribute.rs
@@ -3,7 +3,8 @@ use wasm_bindgen::convert::IntoWasmAbi;
 use wasm_bindgen::JsValue;
 
 use crate::util;
-use crate::value::{FastDiff, NoDiff, Stringify};
+use crate::dom::NoDiff;
+use crate::value::{FastDiff, Stringify};
 use crate::{Element, Mountable, View};
 
 pub trait Attribute {
@@ -101,14 +102,11 @@ where
     }
 }
 
-impl<S> View for AttributeNode<NoDiff<S>>
-where
-    S: Stringify,
-{
+impl View for AttributeNode<NoDiff<&str>> {
     type Product = Element;
 
     fn build(self) -> Self::Product {
-        self.value.stringify(|s| create(self.name, s))
+        create(self.name, self.value.0)
     }
 
     fn update(self, _: &mut Self::Product) {}

--- a/crates/kobold/src/diff.rs
+++ b/crates/kobold/src/diff.rs
@@ -1,0 +1,123 @@
+use crate::dom::NoDiff;
+use crate::value::FastDiff;
+
+pub trait Diff {
+    type State: 'static;
+    type Updated: ?Sized;
+
+    fn init(self) -> Self::State;
+
+    fn update(self, state: &mut Self::State, on_change: impl FnOnce(&Self::Updated));
+}
+
+impl Diff for &str {
+    type State = String;
+    type Updated = str;
+
+    fn init(self) -> String {
+        self.into()
+    }
+
+    fn update(self, state: &mut String, on_change: impl FnOnce(&str)) {
+        if self != state {
+            self.clone_into(state);
+            on_change(&self);
+        }
+    }
+}
+
+impl Diff for String {
+    type State = String;
+    type Updated = str;
+
+    fn init(self) -> String {
+        self
+    }
+
+    fn update(self, state: &mut String, on_change: impl FnOnce(&str)) {
+        if &self != state {
+            on_change(&self);
+            *state = self;
+        }
+    }
+}
+
+impl Diff for &String {
+    type State = String;
+    type Updated = str;
+
+    fn init(self) -> String {
+        self.clone()
+    }
+
+    fn update(self, state: &mut String, on_change: impl FnOnce(&str)) {
+        if self != state {
+            self.clone_into(state);
+            on_change(&self);
+        }
+    }
+}
+
+impl Diff for FastDiff<'_> {
+    type State = usize;
+    type Updated = str;
+
+    fn init(self) -> usize {
+        self.as_ptr() as _
+    }
+
+    fn update(self, state: &mut usize, on_change: impl FnOnce(&str)) {
+        if self.as_ptr() as usize != *state {
+            *state = self.as_ptr() as _;
+            on_change(&self);
+        }
+    }
+}
+
+impl<T> Diff for NoDiff<T> {
+    type State = ();
+    type Updated = T;
+
+    fn init(self) {}
+
+    fn update(self, _: &mut (), on_change: impl FnOnce(&T)) {
+        on_change(&self)
+    }
+}
+
+macro_rules! impl_diff {
+    ($($ty:ty),*) => {
+        $(
+            impl Diff for $ty {
+                type State = $ty;
+                type Updated = $ty;
+
+                fn init(self) -> $ty {
+                    self
+                }
+
+                fn update(self, state: &mut $ty, on_change: impl FnOnce(&Self)) {
+                    if self != *state {
+                        on_change(&self);
+                        *state = self;
+                    }
+                }
+            }
+
+            impl Diff for &$ty {
+                type State = $ty;
+                type Updated = $ty;
+
+                fn init(self) -> $ty {
+                    *self
+                }
+
+                fn update(self, state: &mut $ty, on_change: impl FnOnce(&$ty)) {
+                    (*self).update(state, on_change)
+                }
+            }
+        )*
+    };
+}
+
+impl_diff!(bool, u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize, f32, f64);

--- a/crates/kobold/src/dom.rs
+++ b/crates/kobold/src/dom.rs
@@ -5,6 +5,7 @@ use std::ops::Deref;
 use wasm_bindgen::JsValue;
 use web_sys::Node;
 
+use crate::value::FastDiff;
 use crate::{util, Mountable, View};
 
 #[derive(Clone)]
@@ -58,12 +59,12 @@ impl Deref for Fragment {
     }
 }
 
-pub trait Text: Sized {
-    fn into_text(self) -> Node;
+pub trait Text {
+    fn to_text(&self) -> Node;
 
-    fn update(self, node: &Node);
+    fn set_text(&self, node: &Node);
 
-    fn set_attr(self, el: &JsValue);
+    fn set_attr(&self, el: &JsValue);
 
     #[inline]
     fn no_diff(self) -> NoDiff<Self>
@@ -86,11 +87,48 @@ impl<T> Deref for NoDiff<T> {
     }
 }
 
+impl<T> AsRef<T> for NoDiff<T> {
+    fn as_ref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> Text for NoDiff<T>
+where
+    T: Text,
+{
+    fn to_text(&self) -> Node {
+        self.0.to_text()
+    }
+
+    fn set_text(&self, node: &Node) {
+        self.0.set_text(node);
+    }
+
+    fn set_attr(&self, el: &JsValue) {
+        self.0.set_attr(el);
+    }
+}
+
+impl Text for FastDiff<'_> {
+    fn to_text(&self) -> Node {
+        self.0.to_text()
+    }
+
+    fn set_text(&self, node: &Node) {
+        self.0.set_text(node);
+    }
+
+    fn set_attr(&self, el: &JsValue) {
+        self.0.set_attr(el);
+    }
+}
+
 impl<T: Text + Copy> View for NoDiff<T> {
     type Product = Element;
 
     fn build(self) -> Self::Product {
-        Element::new(self.into_text())
+        Element::new(self.to_text())
     }
 
     fn update(self, _: &mut Self::Product) {}
@@ -100,49 +138,90 @@ macro_rules! impl_text {
     ($($ty:ty),* [$make:ident, $update:ident, $set:ident]) => {
         $(
             impl Text for $ty {
-                fn into_text(self) -> Node {
-                    util::$make(self as _)
+                fn to_text(&self) -> Node {
+                    util::$make(*self as _)
                 }
 
-                fn update(self, node: &Node) {
-                    util::$update(node, self as _);
+                fn set_text(&self, node: &Node) {
+                    util::$update(node, *self as _);
                 }
 
-                fn set_attr(self, el: &JsValue) {
-                    util::$set(el, self as _);
+                fn set_attr(&self, el: &JsValue) {
+                    util::$set(el, *self as _);
+                }
+            }
+
+            impl Text for &$ty {
+                fn to_text(&self) -> Node {
+                    (*self).to_text()
+                }
+
+                fn set_text(&self, node: &Node) {
+                    (*self).set_text(node)
+                }
+
+                fn set_attr(&self, el: &JsValue) {
+                    (*self).set_attr(el)
                 }
             }
         )*
     };
 }
 
-impl_text!(&str [text_node, set_text, set_attr]);
+impl Text for str {
+    fn to_text(&self) -> Node {
+        util::text_node(self)
+    }
+
+    fn set_text(&self, node: &Node) {
+        util::set_text(node, self);
+    }
+
+    fn set_attr(&self, el: &JsValue) {
+        util::set_attr(el, self);
+    }
+}
+
+impl Text for &str {
+    fn to_text(&self) -> Node {
+        (*self).to_text()
+    }
+
+    fn set_text(&self, node: &Node) {
+        (*self).set_text(node)
+    }
+
+    fn set_attr(&self, el: &JsValue) {
+        (*self).set_attr(el)
+    }
+}
+
 impl_text!(bool [text_node_bool, set_text_bool, set_attr_bool]);
 impl_text!(i8, i16, i32, isize, u8, u16, u32, usize, f32, f64 [text_node_num, set_text_num, set_attr_num]);
 
-pub trait LargeInt: Sized + Copy {
+pub trait LargeInt: Sized + Copy + PartialEq + 'static {
     type Downcast: TryFrom<Self> + Text;
 
     fn stringify<F: FnOnce(&str) -> R, R>(&self, f: F) -> R;
 }
 
 impl<S: LargeInt> Text for S {
-    fn into_text(self) -> Node {
-        match S::Downcast::try_from(self) {
-            Ok(downcast) => downcast.into_text(),
+    fn to_text(&self) -> Node {
+        match S::Downcast::try_from(*self) {
+            Ok(downcast) => downcast.to_text(),
             Err(_) => self.stringify(util::text_node),
         }
     }
 
-    fn update(self, node: &Node) {
-        match S::Downcast::try_from(self) {
-            Ok(downcast) => downcast.update(node),
+    fn set_text(&self, node: &Node) {
+        match S::Downcast::try_from(*self) {
+            Ok(downcast) => downcast.set_text(node),
             Err(_) => self.stringify(|s| util::set_text(node, s)),
         }
     }
 
-    fn set_attr(self, el: &JsValue) {
-        match S::Downcast::try_from(self) {
+    fn set_attr(&self, el: &JsValue) {
+        match S::Downcast::try_from(*self) {
             Ok(downcast) => downcast.set_attr(el),
             Err(_) => self.stringify(|s| util::set_attr(el, s)),
         }
@@ -158,7 +237,7 @@ impl Element {
     }
 
     pub fn new_text(text: impl Text) -> Self {
-        Self::new(text.into_text())
+        Self::new(text.to_text())
     }
 
     pub fn new_empty() -> Self {
@@ -175,7 +254,7 @@ impl Element {
     }
 
     pub fn set_text(&self, text: impl Text) {
-        text.update(&self.node);
+        text.set_text(&self.node);
     }
 
     pub fn anchor(&self) -> &JsValue {

--- a/crates/kobold/src/dom.rs
+++ b/crates/kobold/src/dom.rs
@@ -97,7 +97,7 @@ impl<T: Text + Copy> View for NoDiff<T> {
 }
 
 macro_rules! impl_text {
-    ($make:ident, $update:ident, $set:ident; $($ty:ty),*) => {
+    ($($ty:ty),* [$make:ident, $update:ident, $set:ident]) => {
         $(
             impl Text for $ty {
                 fn into_text(self) -> Node {
@@ -116,11 +116,9 @@ macro_rules! impl_text {
     };
 }
 
-impl_text!(text_node, set_text, set_attr; &str);
-impl_text!(text_node_bool, set_text_bool, set_attr_bool; bool);
-impl_text!(text_node_u32, set_text_u32, set_attr_u32; u8, u16, u32, usize);
-impl_text!(text_node_i32, set_text_i32, set_attr_i32; i8, i16, i32, isize);
-impl_text!(text_node_f64, set_text_f64, set_attr_f64; f32, f64);
+impl_text!(&str [text_node, set_text, set_attr]);
+impl_text!(bool [text_node_bool, set_text_bool, set_attr_bool]);
+impl_text!(i8, i16, i32, isize, u8, u16, u32, usize, f32, f64 [text_node_num, set_text_num, set_attr_num]);
 
 pub trait LargeInt: Sized + Copy {
     type Downcast: TryFrom<Self> + Text;

--- a/crates/kobold/src/dom.rs
+++ b/crates/kobold/src/dom.rs
@@ -141,8 +141,11 @@ impl<S: LargeInt> Text for S {
         }
     }
 
-    fn set_attr(self, _el: &JsValue) {
-        todo!();
+    fn set_attr(self, el: &JsValue) {
+        match S::Downcast::try_from(self) {
+            Ok(downcast) => downcast.set_attr(el),
+            Err(_) => self.stringify(|s| util::set_attr(el, s)),
+        }
     }
 }
 

--- a/crates/kobold/src/dom.rs
+++ b/crates/kobold/src/dom.rs
@@ -65,8 +65,6 @@ pub trait Text: Sized {
 
     fn set_attr(self, el: &JsValue);
 
-    fn as_js(&self) -> JsValue;
-
     #[inline]
     fn no_diff(self) -> NoDiff<Self>
     where
@@ -99,7 +97,7 @@ impl<T: Text + Copy> View for NoDiff<T> {
 }
 
 macro_rules! impl_text {
-    ($make:ident, $update:ident, $set:ident, $from:ident; $($ty:ty),*) => {
+    ($make:ident, $update:ident, $set:ident; $($ty:ty),*) => {
         $(
             impl Text for $ty {
                 fn into_text(self) -> Node {
@@ -113,21 +111,16 @@ macro_rules! impl_text {
                 fn set_attr(self, el: &JsValue) {
                     util::$set(el, self as _);
                 }
-
-                fn as_js(&self) -> JsValue {
-                    // panic!()
-                    JsValue::$from(*self as _)
-                }
             }
         )*
     };
 }
 
-impl_text!(text_node, set_text, set_attr, from_str; &str);
-impl_text!(text_node_bool, set_text_bool, set_attr_bool, from_bool; bool);
-impl_text!(text_node_u32, set_text_u32, set_attr_u32, from_f64; u8, u16, u32, usize);
-impl_text!(text_node_i32, set_text_i32, set_attr_i32, from_f64; i8, i16, i32, isize);
-impl_text!(text_node_f64, set_text_f64, set_attr_f64, from_f64; f32, f64);
+impl_text!(text_node, set_text, set_attr; &str);
+impl_text!(text_node_bool, set_text_bool, set_attr_bool; bool);
+impl_text!(text_node_u32, set_text_u32, set_attr_u32; u8, u16, u32, usize);
+impl_text!(text_node_i32, set_text_i32, set_attr_i32; i8, i16, i32, isize);
+impl_text!(text_node_f64, set_text_f64, set_attr_f64; f32, f64);
 
 pub trait LargeInt: Sized + Copy {
     type Downcast: TryFrom<Self> + Text;
@@ -152,13 +145,6 @@ impl<S: LargeInt> Text for S {
 
     fn set_attr(self, _el: &JsValue) {
         todo!();
-    }
-
-    fn as_js(&self) -> JsValue {
-        match S::Downcast::try_from(*self) {
-            Ok(downcast) => downcast.as_js(),
-            Err(_) => self.stringify(JsValue::from_str),
-        }
     }
 }
 

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -305,7 +305,7 @@ pub mod prelude {
     pub use crate::dom::Text as _;
     pub use crate::event::{Event, KeyboardEvent, MouseEvent};
     pub use crate::list::ListIteratorExt as _;
-    pub use crate::value::{StrExt as _, Stringify as _};
+    pub use crate::value::StrExt as _;
     pub use crate::{bind, class};
     pub use crate::{component, view, View};
 
@@ -430,7 +430,7 @@ pub fn start(html: impl View) {
 
     let product = ManuallyDrop::new(html.build());
 
-    util::__kobold_start(product.js());
+    util::append_body(product.js());
 }
 
 fn init_panic_hook() {

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -302,6 +302,7 @@ pub mod stateful;
 /// use kobold::prelude::*;
 /// ```
 pub mod prelude {
+    pub use crate::dom::Text as _;
     pub use crate::event::{Event, KeyboardEvent, MouseEvent};
     pub use crate::list::ListIteratorExt as _;
     pub use crate::value::{StrExt as _, Stringify as _};

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -286,6 +286,7 @@ use wasm_bindgen::{JsCast, JsValue};
 
 pub mod attribute;
 pub mod branching;
+pub mod diff;
 pub mod dom;
 pub mod event;
 pub mod list;

--- a/crates/kobold/src/util.rs
+++ b/crates/kobold/src/util.rs
@@ -4,7 +4,7 @@ use web_sys::Node;
 use crate::dom::Element;
 use crate::View;
 
-pub struct Static<F>(pub F);
+pub struct Static<F = fn() -> Node>(pub F);
 
 impl<F> View for Static<F>
 where
@@ -37,8 +37,23 @@ extern "C" {
     pub(crate) fn __kobold_fragment_drop(f: &Node);
 
     pub(crate) fn __kobold_text_node(t: &str) -> Node;
-
+    #[wasm_bindgen(js_name = "__kobold_text_node_coerce")]
+    pub(crate) fn __kobold_text_node_uint(t: u32) -> Node;
+    #[wasm_bindgen(js_name = "__kobold_text_node_coerce")]
+    pub(crate) fn __kobold_text_node_int(t: i32) -> Node;
+    #[wasm_bindgen(js_name = "__kobold_text_node_coerce")]
+    pub(crate) fn __kobold_text_node_float(t: f64) -> Node;
+    #[wasm_bindgen(js_name = "__kobold_text_node_coerce")]
+    pub(crate) fn __kobold_text_node_bool(t: bool) -> Node;
     pub(crate) fn __kobold_update_text(node: &Node, t: &str);
+    #[wasm_bindgen(js_name = "__kobold_update_text_coerce")]
+    pub(crate) fn __kobold_update_text_uint(node: &Node, t: u32);
+    #[wasm_bindgen(js_name = "__kobold_update_text_coerce")]
+    pub(crate) fn __kobold_update_text_int(node: &Node, t: i32);
+    #[wasm_bindgen(js_name = "__kobold_update_text_coerce")]
+    pub(crate) fn __kobold_update_text_float(node: &Node, t: f64);
+    #[wasm_bindgen(js_name = "__kobold_update_text_coerce")]
+    pub(crate) fn __kobold_update_text_bool(node: &Node, t: bool);
 
     pub(crate) fn __kobold_attr(name: &str, value: &str) -> Node;
     pub(crate) fn __kobold_attr_class(value: &str) -> Node;

--- a/crates/kobold/src/util.rs
+++ b/crates/kobold/src/util.rs
@@ -28,13 +28,13 @@ extern "C" {
     pub(crate) fn text_node(t: &str) -> Node;
 
     #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
-    pub(crate) fn text_node_uint(t: u32) -> Node;
+    pub(crate) fn text_node_u32(t: u32) -> Node;
 
     #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
-    pub(crate) fn text_node_int(t: i32) -> Node;
+    pub(crate) fn text_node_i32(t: i32) -> Node;
 
     #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
-    pub(crate) fn text_node_float(t: f64) -> Node;
+    pub(crate) fn text_node_f64(t: f64) -> Node;
 
     #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
     pub(crate) fn text_node_bool(t: bool) -> Node;
@@ -42,8 +42,6 @@ extern "C" {
 
 #[wasm_bindgen(module = "/js/util.js")]
 extern "C" {
-    pub(crate) fn __kobold_start(node: &JsValue);
-
     pub(crate) fn __kobold_append(parent: &Node, child: &JsValue);
     pub(crate) fn __kobold_before(node: &Node, insert: &JsValue);
     pub(crate) fn __kobold_unmount(node: &JsValue);
@@ -57,26 +55,51 @@ extern "C" {
     pub(crate) fn __kobold_fragment_replace(f: &Node, new: &JsValue);
     pub(crate) fn __kobold_fragment_drop(f: &Node);
 
-    #[wasm_bindgen(js_name = "__kobold_update_text")]
-    pub(crate) fn update_text(node: &Node, t: &str);
-    #[wasm_bindgen(js_name = "__kobold_update_text")]
-    pub(crate) fn update_text_uint(node: &Node, t: u32);
-    #[wasm_bindgen(js_name = "__kobold_update_text")]
-    pub(crate) fn update_text_int(node: &Node, t: i32);
-    #[wasm_bindgen(js_name = "__kobold_update_text")]
-    pub(crate) fn update_text_float(node: &Node, t: f64);
-    #[wasm_bindgen(js_name = "__kobold_update_text")]
-    pub(crate) fn update_text_bool(node: &Node, t: bool);
+    // `set_text` variants ----------------
 
-    pub(crate) fn __kobold_attr(name: &str, value: &str) -> Node;
-    pub(crate) fn __kobold_attr_class(value: &str) -> Node;
-    pub(crate) fn __kobold_attr_style(value: &str) -> Node;
-    pub(crate) fn __kobold_attr_set(node: &JsValue, name: &str, value: &str) -> Node;
-    pub(crate) fn __kobold_attr_update(node: &Node, value: &str);
+    #[wasm_bindgen(js_name = "__kobold_set_text")]
+    pub(crate) fn set_text(node: &Node, t: &str);
+    #[wasm_bindgen(js_name = "__kobold_set_text")]
+    pub(crate) fn set_text_u32(node: &Node, t: u32);
+    #[wasm_bindgen(js_name = "__kobold_set_text")]
+    pub(crate) fn set_text_i32(node: &Node, t: i32);
+    #[wasm_bindgen(js_name = "__kobold_set_text")]
+    pub(crate) fn set_text_f64(node: &Node, t: f64);
+    #[wasm_bindgen(js_name = "__kobold_set_text")]
+    pub(crate) fn set_text_bool(node: &Node, t: bool);
 
-    pub(crate) fn __kobold_attr_checked_set(el: &JsValue, value: bool);
-    pub(crate) fn __kobold_class_set(el: &JsValue, value: &str);
-    pub(crate) fn __kobold_class_add(el: &JsValue, value: &str);
-    pub(crate) fn __kobold_class_remove(el: &JsValue, value: &str);
-    pub(crate) fn __kobold_class_replace(el: &JsValue, old: &str, value: &str);
+    // `set_attr` variants ----------------
+
+    #[wasm_bindgen(js_name = "__kobold_set_attr")]
+    pub(crate) fn set_attr(el: &JsValue, v: &str);
+    #[wasm_bindgen(js_name = "__kobold_set_attr")]
+    pub(crate) fn set_attr_u32(el: &JsValue, v: u32);
+    #[wasm_bindgen(js_name = "__kobold_set_attr")]
+    pub(crate) fn set_attr_i32(el: &JsValue, v: i32);
+    #[wasm_bindgen(js_name = "__kobold_set_attr")]
+    pub(crate) fn set_attr_f64(el: &JsValue, v: f64);
+    #[wasm_bindgen(js_name = "__kobold_set_attr")]
+    pub(crate) fn set_attr_bool(el: &JsValue, v: bool);
+
+    // provided attribute constructors ----------------
+
+    #[wasm_bindgen(js_name = "__kobold_attr_href")]
+    pub(crate) fn href() -> Node;
+    #[wasm_bindgen(js_name = "__kobold_attr_style")]
+    pub(crate) fn style() -> Node;
+    #[wasm_bindgen(js_name = "__kobold_attr_value")]
+    pub(crate) fn value() -> Node;
+
+    // ----------------
+
+    #[wasm_bindgen(js_name = "__kobold_set_checked")]
+    pub(crate) fn set_checked(el: &JsValue, value: bool);
+    #[wasm_bindgen(js_name = "__kobold_set_class_name")]
+    pub(crate) fn set_class_name(el: &JsValue, value: &str);
+    #[wasm_bindgen(js_name = "__kobold_add_class")]
+    pub(crate) fn add_class(el: &JsValue, value: &str);
+    #[wasm_bindgen(js_name = "__kobold_remove_class")]
+    pub(crate) fn remove_class(el: &JsValue, value: &str);
+    #[wasm_bindgen(js_name = "__kobold_replace_class")]
+    pub(crate) fn replace_class(el: &JsValue, old: &str, value: &str);
 }

--- a/crates/kobold/src/util.rs
+++ b/crates/kobold/src/util.rs
@@ -19,6 +19,27 @@ where
     fn update(self, _: &mut Element) {}
 }
 
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = ["document", "body"], js_name = appendChild)]
+    pub(crate) fn append_body(node: &JsValue);
+
+    #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
+    pub(crate) fn text_node(t: &str) -> Node;
+
+    #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
+    pub(crate) fn text_node_uint(t: u32) -> Node;
+
+    #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
+    pub(crate) fn text_node_int(t: i32) -> Node;
+
+    #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
+    pub(crate) fn text_node_float(t: f64) -> Node;
+
+    #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
+    pub(crate) fn text_node_bool(t: bool) -> Node;
+}
+
 #[wasm_bindgen(module = "/js/util.js")]
 extern "C" {
     pub(crate) fn __kobold_start(node: &JsValue);
@@ -36,24 +57,16 @@ extern "C" {
     pub(crate) fn __kobold_fragment_replace(f: &Node, new: &JsValue);
     pub(crate) fn __kobold_fragment_drop(f: &Node);
 
-    pub(crate) fn __kobold_text_node(t: &str) -> Node;
-    #[wasm_bindgen(js_name = "__kobold_text_node_coerce")]
-    pub(crate) fn __kobold_text_node_uint(t: u32) -> Node;
-    #[wasm_bindgen(js_name = "__kobold_text_node_coerce")]
-    pub(crate) fn __kobold_text_node_int(t: i32) -> Node;
-    #[wasm_bindgen(js_name = "__kobold_text_node_coerce")]
-    pub(crate) fn __kobold_text_node_float(t: f64) -> Node;
-    #[wasm_bindgen(js_name = "__kobold_text_node_coerce")]
-    pub(crate) fn __kobold_text_node_bool(t: bool) -> Node;
-    pub(crate) fn __kobold_update_text(node: &Node, t: &str);
-    #[wasm_bindgen(js_name = "__kobold_update_text_coerce")]
-    pub(crate) fn __kobold_update_text_uint(node: &Node, t: u32);
-    #[wasm_bindgen(js_name = "__kobold_update_text_coerce")]
-    pub(crate) fn __kobold_update_text_int(node: &Node, t: i32);
-    #[wasm_bindgen(js_name = "__kobold_update_text_coerce")]
-    pub(crate) fn __kobold_update_text_float(node: &Node, t: f64);
-    #[wasm_bindgen(js_name = "__kobold_update_text_coerce")]
-    pub(crate) fn __kobold_update_text_bool(node: &Node, t: bool);
+    #[wasm_bindgen(js_name = "__kobold_update_text")]
+    pub(crate) fn update_text(node: &Node, t: &str);
+    #[wasm_bindgen(js_name = "__kobold_update_text")]
+    pub(crate) fn update_text_uint(node: &Node, t: u32);
+    #[wasm_bindgen(js_name = "__kobold_update_text")]
+    pub(crate) fn update_text_int(node: &Node, t: i32);
+    #[wasm_bindgen(js_name = "__kobold_update_text")]
+    pub(crate) fn update_text_float(node: &Node, t: f64);
+    #[wasm_bindgen(js_name = "__kobold_update_text")]
+    pub(crate) fn update_text_bool(node: &Node, t: bool);
 
     pub(crate) fn __kobold_attr(name: &str, value: &str) -> Node;
     pub(crate) fn __kobold_attr_class(value: &str) -> Node;

--- a/crates/kobold/src/util.rs
+++ b/crates/kobold/src/util.rs
@@ -23,19 +23,10 @@ where
 extern "C" {
     #[wasm_bindgen(js_namespace = ["document", "body"], js_name = appendChild)]
     pub(crate) fn append_body(node: &JsValue);
-
     #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
     pub(crate) fn text_node(t: &str) -> Node;
-
     #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
-    pub(crate) fn text_node_u32(t: u32) -> Node;
-
-    #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
-    pub(crate) fn text_node_i32(t: i32) -> Node;
-
-    #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
-    pub(crate) fn text_node_f64(t: f64) -> Node;
-
+    pub(crate) fn text_node_num(t: f64) -> Node;
     #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
     pub(crate) fn text_node_bool(t: bool) -> Node;
 }
@@ -60,11 +51,7 @@ extern "C" {
     #[wasm_bindgen(js_name = "__kobold_set_text")]
     pub(crate) fn set_text(node: &Node, t: &str);
     #[wasm_bindgen(js_name = "__kobold_set_text")]
-    pub(crate) fn set_text_u32(node: &Node, t: u32);
-    #[wasm_bindgen(js_name = "__kobold_set_text")]
-    pub(crate) fn set_text_i32(node: &Node, t: i32);
-    #[wasm_bindgen(js_name = "__kobold_set_text")]
-    pub(crate) fn set_text_f64(node: &Node, t: f64);
+    pub(crate) fn set_text_num(node: &Node, t: f64);
     #[wasm_bindgen(js_name = "__kobold_set_text")]
     pub(crate) fn set_text_bool(node: &Node, t: bool);
 
@@ -73,11 +60,7 @@ extern "C" {
     #[wasm_bindgen(js_name = "__kobold_set_attr")]
     pub(crate) fn set_attr(el: &JsValue, v: &str);
     #[wasm_bindgen(js_name = "__kobold_set_attr")]
-    pub(crate) fn set_attr_u32(el: &JsValue, v: u32);
-    #[wasm_bindgen(js_name = "__kobold_set_attr")]
-    pub(crate) fn set_attr_i32(el: &JsValue, v: i32);
-    #[wasm_bindgen(js_name = "__kobold_set_attr")]
-    pub(crate) fn set_attr_f64(el: &JsValue, v: f64);
+    pub(crate) fn set_attr_num(el: &JsValue, v: f64);
     #[wasm_bindgen(js_name = "__kobold_set_attr")]
     pub(crate) fn set_attr_bool(el: &JsValue, v: bool);
 

--- a/crates/kobold_macros/src/gen/element.rs
+++ b/crates/kobold_macros/src/gen/element.rs
@@ -129,10 +129,21 @@ impl IntoGenerator for HtmlElement {
                         writeln!(el, "{var}.{attr}={value};");
 
                         JsArgument::with_abi(value, "bool")
+                    } else if provided_attr(attr) {
+                        let value = gen.add_expression(call(
+                            format_args!("::kobold::attribute::{attr}"),
+                            expr.stream,
+                        ));
+
+                        writeln!(el, "{var}.setAttributeNode({value});");
+
+                        JsArgument::new(value)
                     } else {
+                        let attr_fn = gen.attribute_constructor(attr);
+
                         let value = gen.add_expression(call(
                             "::kobold::attribute::AttributeNode::new",
-                            (string(attr), ',', expr.stream),
+                            (ident(&attr_fn), ',', expr.stream),
                         ));
 
                         writeln!(el, "{var}.setAttributeNode({value});");
@@ -151,6 +162,16 @@ impl IntoGenerator for HtmlElement {
         }
 
         DomNode::Element(el)
+    }
+}
+
+#[rustfmt::skip]
+fn provided_attr(attr: &str) -> bool {
+    match attr {
+        "href"
+        | "style"
+        | "value" => true,
+        _ => false,
     }
 }
 

--- a/examples/todomvc/index.html
+++ b/examples/todomvc/index.html
@@ -12,7 +12,6 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/todomvc-app-css@2.4.2/index.css"
     />
-
     <link data-trunk rel="rust" />
   </head>
   <body></body>


### PR DESCRIPTION
This lets us skip `ryu` as dependency. `u64`, `u128`, `i64`, and `128` are still passed as strings via `itoa` since they might not fit in the JS number type.