### PR TITLE
Refactor text values and attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,6 @@ dependencies = [
  "console_error_panic_hook",
  "itoa",
  "kobold_macros",
- "ryu",
  "wasm-bindgen",
  "web-sys",
 ]

--- a/crates/kobold/Cargo.toml
+++ b/crates/kobold/Cargo.toml
@@ -17,8 +17,7 @@ stateful = []
 
 [dependencies]
 wasm-bindgen = "0.2.84"
-itoa = "1.0.1"
-ryu = "1.0.12"
+itoa = "1.0.6"
 kobold_macros = { version = "0.5.0", path = "../kobold_macros" }
 console_error_panic_hook = "0.1.7"
 

--- a/crates/kobold/js/util.js
+++ b/crates/kobold/js/util.js
@@ -40,14 +40,12 @@ export function __kobold_fragment_drop(f)
 export function __kobold_set_text(n,t) { n.textContent = t; }
 export function __kobold_set_attr(n,a,v) { n.setAttribute(a, v); }
 
-export function __kobold_attr_href() { return document.createAttribute("href"); }
-export function __kobold_attr_style() { return document.createAttribute("style"); }
-export function __kobold_attr_value() { return document.createAttribute("value"); }
+export function __kobold_checked(n,v) { if (n.checked !== v) n.checked = v; }
+export function __kobold_class_name(n,v) { n.className = v; }
+export function __kobold_href(n,v) { n.href = v; }
+export function __kobold_style(n,v) { n.style = v; }
+export function __kobold_value(n,v) { n.value = v; }
 
-export function __kobold_set_attr_value(a,v) { a.value = v; }
-
-export function __kobold_set_checked(n,v) { if (n.checked !== v) n.checked = v; }
-export function __kobold_set_class_name(n,v) { n.className = v; }
 export function __kobold_add_class(n,v) { n.classList.add(v); }
 export function __kobold_remove_class(n,v) { n.classList.remove(v); }
 export function __kobold_replace_class(n,o,v) { n.classList.replace(o,v); }

--- a/crates/kobold/js/util.js
+++ b/crates/kobold/js/util.js
@@ -38,11 +38,13 @@ export function __kobold_fragment_drop(f)
 }
 
 export function __kobold_set_text(n,t) { n.textContent = t; }
-export function __kobold_set_attr(a,v) { a.value = v; }
+export function __kobold_set_attr(n,a,v) { n.setAttribute(a, v); }
 
 export function __kobold_attr_href() { return document.createAttribute("href"); }
 export function __kobold_attr_style() { return document.createAttribute("style"); }
 export function __kobold_attr_value() { return document.createAttribute("value"); }
+
+export function __kobold_set_attr_value(a,v) { a.value = v; }
 
 export function __kobold_set_checked(n,v) { if (n.checked !== v) n.checked = v; }
 export function __kobold_set_class_name(n,v) { n.className = v; }

--- a/crates/kobold/js/util.js
+++ b/crates/kobold/js/util.js
@@ -49,3 +49,4 @@ export function __kobold_value(n,v) { n.value = v; }
 export function __kobold_add_class(n,v) { n.classList.add(v); }
 export function __kobold_remove_class(n,v) { n.classList.remove(v); }
 export function __kobold_replace_class(n,o,v) { n.classList.replace(o,v); }
+export function __kobold_toggle_class(n,c,v) { n.classList.toggle(c,v); }

--- a/crates/kobold/js/util.js
+++ b/crates/kobold/js/util.js
@@ -37,16 +37,15 @@ export function __kobold_fragment_drop(f)
 	delete f.$end;
 }
 
-export function __kobold_update_text(n,t) { n.textContent = t; }
+export function __kobold_set_text(n,t) { n.textContent = t; }
+export function __kobold_set_attr(a,v) { a.value = v; }
 
-export function __kobold_attr(n,v) { let a = document.createAttribute(n); a.value = v; return a; }
-export function __kobold_attr_class(v) { let a = document.createAttribute('class'); a.value = v; return a; }
-export function __kobold_attr_style(v) { let a = document.createAttribute('style'); a.value = v; return a; }
-export function __kobold_attr_set(n,k,v) { n.setAttribute(k, v); }
-export function __kobold_attr_update(n,v) { n.value = v; }
+export function __kobold_attr_href() { return document.createAttribute("href"); }
+export function __kobold_attr_style() { return document.createAttribute("style"); }
+export function __kobold_attr_value() { return document.createAttribute("value"); }
 
-export function __kobold_attr_checked_set(n,v) { if (n.checked !== v) n.checked = v; }
-export function __kobold_class_set(n,v) { n.className = v; }
-export function __kobold_class_add(n,v) { n.classList.add(v); }
-export function __kobold_class_remove(n,v) { n.classList.remove(v); }
-export function __kobold_class_replace(n,o,v) { n.classList.replace(o,v); }
+export function __kobold_set_checked(n,v) { if (n.checked !== v) n.checked = v; }
+export function __kobold_set_class_name(n,v) { n.className = v; }
+export function __kobold_add_class(n,v) { n.classList.add(v); }
+export function __kobold_remove_class(n,v) { n.classList.remove(v); }
+export function __kobold_replace_class(n,o,v) { n.classList.replace(o,v); }

--- a/crates/kobold/js/util.js
+++ b/crates/kobold/js/util.js
@@ -1,7 +1,5 @@
 const fragmentDecorators = new WeakMap();
 
-export function __kobold_start(n) { document.body.appendChild(n); }
-
 export function __kobold_append(n,c) { n.appendChild(c); }
 export function __kobold_before(n,i) { n.before(i); }
 export function __kobold_unmount(n) { n.remove(); }
@@ -38,10 +36,8 @@ export function __kobold_fragment_drop(f)
 	delete f.$begin;
 	delete f.$end;
 }
-export function __kobold_text_node(t) { return document.createTextNode(t); }
-export function __kobold_text_node_coerce(t) { return document.createTextNode(t.toString()); }
+
 export function __kobold_update_text(n,t) { n.textContent = t; }
-export function __kobold_update_text_coerce(n,t) { n.textContent = t.toString(); }
 
 export function __kobold_attr(n,v) { let a = document.createAttribute(n); a.value = v; return a; }
 export function __kobold_attr_class(v) { let a = document.createAttribute('class'); a.value = v; return a; }

--- a/crates/kobold/js/util.js
+++ b/crates/kobold/js/util.js
@@ -39,7 +39,9 @@ export function __kobold_fragment_drop(f)
 	delete f.$end;
 }
 export function __kobold_text_node(t) { return document.createTextNode(t); }
+export function __kobold_text_node_coerce(t) { return document.createTextNode(t.toString()); }
 export function __kobold_update_text(n,t) { n.textContent = t; }
+export function __kobold_update_text_coerce(n,t) { n.textContent = t.toString(); }
 
 export function __kobold_attr(n,v) { let a = document.createAttribute(n); a.value = v; return a; }
 export function __kobold_attr_class(v) { let a = document.createAttribute('class'); a.value = v; return a; }

--- a/crates/kobold/src/attribute.rs
+++ b/crates/kobold/src/attribute.rs
@@ -217,6 +217,16 @@ pub struct OptionalClass {
     on: bool,
 }
 
+impl AsRef<str> for OptionalClass {
+    fn as_ref(&self) -> &str {
+        if self.on {
+            self.class
+        } else {
+            ""
+        }
+    }
+}
+
 impl OptionalClass {
     pub const fn new(class: &'static str, on: bool) -> Self {
         OptionalClass { class, on }
@@ -233,12 +243,35 @@ impl AttributeView<Class> for OptionalClass {
 
     fn build_in(self, _: Class, node: &Node) -> bool {
         util::toggle_class(node, self.class, self.on);
-        self.build()
+        self.on
     }
 
     fn update_in(self, _: Class, node: &Node, memo: &mut bool) {
         if self.on != *memo {
             util::toggle_class(node, self.class, self.on);
+            *memo = self.on;
+        }
+    }
+}
+
+impl AttributeView<ClassName> for OptionalClass {
+    type Product = bool;
+
+    fn build(self) -> bool {
+        debug_test_class(self.class);
+        self.on
+    }
+
+    fn build_in(self, _: ClassName, node: &Node) -> bool {
+        if self.on {
+            util::class_name(node, self.class);
+        }
+        self.on
+    }
+
+    fn update_in(self, _: ClassName, node: &Node, memo: &mut bool) {
+        if self.on != *memo {
+            util::class_name(node, self.as_ref());
             *memo = self.on;
         }
     }

--- a/crates/kobold/src/attribute.rs
+++ b/crates/kobold/src/attribute.rs
@@ -2,9 +2,9 @@
 use wasm_bindgen::convert::IntoWasmAbi;
 use wasm_bindgen::JsValue;
 
+use crate::dom::{LargeInt, NoDiff};
 use crate::util;
-use crate::dom::NoDiff;
-use crate::value::{FastDiff, Stringify};
+use crate::value::FastDiff;
 use crate::{Element, Mountable, View};
 
 pub trait Attribute {
@@ -81,7 +81,7 @@ impl View for AttributeNode<&String> {
 
 impl<S> View for AttributeNode<S>
 where
-    S: Stringify + Eq + Copy + 'static,
+    S: LargeInt + Eq + Copy + 'static,
 {
     type Product = AttributeNodeProduct<S>;
 

--- a/crates/kobold/src/attribute.rs
+++ b/crates/kobold/src/attribute.rs
@@ -3,7 +3,8 @@ use wasm_bindgen::convert::IntoWasmAbi;
 use wasm_bindgen::JsValue;
 
 use crate::util;
-use crate::value::{FastDiff, NoDiff, Stringify};
+use crate::dom::NoDiff;
+use crate::value::{FastDiff, Stringify};
 use crate::{Element, Mountable, View};
 
 pub trait Attribute {
@@ -101,14 +102,11 @@ where
     }
 }
 
-impl<S> View for AttributeNode<NoDiff<S>>
-where
-    S: Stringify,
-{
+impl View for AttributeNode<NoDiff<&str>> {
     type Product = Element;
 
     fn build(self) -> Self::Product {
-        self.value.stringify(|s| create(self.name, s))
+        create(self.name, self.value.0)
     }
 
     fn update(self, _: &mut Self::Product) {}

--- a/crates/kobold/src/attribute.rs
+++ b/crates/kobold/src/attribute.rs
@@ -4,9 +4,36 @@ use wasm_bindgen::JsValue;
 use web_sys::Node;
 
 use crate::diff::Diff;
-use crate::dom::{NoDiff, Text};
+use crate::dom::{NoDiff, Text, Property};
 use crate::util;
 use crate::{Element, Mountable, View};
+
+pub struct Attr(pub &'static str);
+pub struct Checked;
+
+impl Property<&str> for Attr {
+    fn set(self, this: &JsValue, value: &str) {
+        util::set_attr(this, self.0, value)
+    }
+}
+
+impl Property<f64> for Attr {
+    fn set(self, this: &JsValue, value: f64) {
+        util::set_attr_num(this, self.0, value)
+    }
+}
+
+impl Property<bool> for Attr {
+    fn set(self, this: &JsValue, value: bool) {
+        util::set_attr_bool(this, self.0, value)
+    }
+}
+
+impl Property<bool> for Checked {
+    fn set(self, this: &JsValue, value: bool) {
+        util::set_checked(this, value)
+    }
+}
 
 pub struct AttributeNode<A, V> {
     constructor: A,
@@ -236,27 +263,27 @@ impl<'a> Attribute for ClassName<NoDiff<OptionalClass<'a>>> {
     }
 }
 
-/// The `checked` attribute for `<input>` elements
-pub struct Checked(pub bool);
+// /// The `checked` attribute for `<input>` elements
+// pub struct Checked(pub bool);
 
-impl Attribute for Checked {
-    type Abi = bool;
-    type Product = ();
+// impl Attribute for Checked {
+//     type Abi = bool;
+//     type Product = ();
 
-    fn js(&self) -> Self::Abi {
-        self.0
-    }
+//     fn js(&self) -> Self::Abi {
+//         self.0
+//     }
 
-    fn build(self) -> Self::Product {}
+//     fn build(self) -> Self::Product {}
 
-    fn update(self, _: &mut Self::Product, js: &JsValue) {
-        // Checkboxes are weird because a `click` or `change` event
-        // can affect the state without reflecting it on the product.
-        //
-        // Best to do the diff in the DOM directly.
-        util::set_checked(js, self.0);
-    }
-}
+//     fn update(self, _: &mut Self::Product, js: &JsValue) {
+//         // Checkboxes are weird because a `click` or `change` event
+//         // can affect the state without reflecting it on the product.
+//         //
+//         // Best to do the diff in the DOM directly.
+//         util::set_checked(js, self.0);
+//     }
+// }
 
 pub struct AttributeNodeProduct<V> {
     state: V,

--- a/crates/kobold/src/attribute.rs
+++ b/crates/kobold/src/attribute.rs
@@ -153,7 +153,7 @@ fn debug_test_class(class: &str) {
 
 fn set_class(node: &Node, class: &str) {
     if !class.is_empty() {
-        util::add_class(node, class.as_ref());
+        util::add_class(node, class);
     }
 }
 

--- a/crates/kobold/src/attribute.rs
+++ b/crates/kobold/src/attribute.rs
@@ -1,299 +1,282 @@
 //! Utilities for dealing with DOM attributes
-use wasm_bindgen::convert::IntoWasmAbi;
-use wasm_bindgen::JsValue;
 use web_sys::Node;
 
+use crate::value::Value;
+use crate::dom::Property;
 use crate::diff::Diff;
-use crate::dom::{NoDiff, Text, Property};
 use crate::util;
-use crate::{Element, Mountable, View};
 
-pub struct Checked;
+/// Arbitrary attribute: <https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute>
+pub type Attribute = &'static str;
 
-impl Property<&str> for &str {
-    fn set(self, this: &JsValue, value: &str) {
+impl Property<&str> for Attribute {
+    fn set(self, this: &Node, value: &str) {
         util::set_attr(this, self, value)
     }
 }
 
-impl Property<f64> for &str {
-    fn set(self, this: &JsValue, value: f64) {
+impl Property<f64> for Attribute {
+    fn set(self, this: &Node, value: f64) {
         util::set_attr_num(this, self, value)
     }
 }
 
-impl Property<bool> for &str {
-    fn set(self, this: &JsValue, value: bool) {
+impl Property<bool> for Attribute {
+    fn set(self, this: &Node, value: bool) {
         util::set_attr_bool(this, self, value)
     }
 }
 
-impl Property<bool> for Checked {
-    fn set(self, this: &JsValue, value: bool) {
-        util::set_checked(this, value)
-    }
-}
-
-pub struct AttributeNode<A, V> {
-    constructor: A,
-    value: V,
-}
-
-macro_rules! def_attr {
-    ($($name:ident,)*) => {
+macro_rules! attribute {
+    ($(#[doc = $doc:literal] $name:ident [ $($util:ident: $abi:ty),* ])*) => {
         $(
-            #[doc = concat!("The `", stringify!($name) ,"` attribute constructor")]
-            pub fn $name<V>(value: V) -> AttributeNode<impl Fn() -> Node, V> {
-                AttributeNode::new(util::$name, value)
-            }
+            #[doc = $doc]
+            pub struct $name;
+
+            $(
+                impl Property<$abi> for $name {
+                    fn set(self, this: &Node, value: $abi) {
+                        util::$util(this, value)
+                    }
+                }
+            )*
         )*
-    };
-}
-
-def_attr! {
-    href,
-    style,
-    value,
-}
-
-impl<A, T> AttributeNode<A, T> {
-    pub const fn new(constructor: A, value: T) -> Self {
-        AttributeNode { constructor, value }
     }
 }
 
-impl<A, T> View for AttributeNode<A, T>
-where
-    A: Fn() -> Node,
-    T: Text + Diff + Copy,
-{
-    type Product = AttributeNodeProduct<T::State>;
+attribute!(
+    /// The `checked` attribute: <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#checked>
+    Checked [checked: bool]
+    /// The `className` attribute: <https://developer.mozilla.org/en-US/docs/Web/API/Element/className>
+    ClassName [class_name: &str]
+    /// The `style` attribute: <https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style>
+    Style [style: &str]
+    /// The `href` attribute: <https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/href>
+    Href [href: &str]
+    /// The `value` attribute: <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#value>
+    InputValue [value: &str, value_num: f64]
+);
 
-    fn build(self) -> Self::Product {
-        let el = Element::new((self.constructor)());
-
-        self.value.set_attr(&el);
-        let state = self.value.init();
-
-        AttributeNodeProduct { state, el }
-    }
-
-    fn update(self, p: &mut Self::Product) {
-        if self.value.update(&mut p.state) {
-            self.value.set_attr(&p.el);
-        }
-    }
-}
-
-pub trait Attribute {
-    type Abi: IntoWasmAbi;
+pub trait AttributeView<P> {
     type Product: 'static;
 
-    fn js(&self) -> Self::Abi;
+    fn build_in(self, prop: P, node: &Node) -> Self::Product;
 
-    fn build(self) -> Self::Product;
-
-    fn update(self, p: &mut Self::Product, el: &JsValue);
+    fn update_in(self, prop: P, node: &Node, memo: &mut Self::Product);
 }
 
-/// A class that interacts with `classList` property of an element
-///
-/// <https://developer.mozilla.org/en-US/docs/Web/API/Element/classList>
-#[repr(transparent)]
-pub struct Class<T>(T);
+impl<P, T> AttributeView<P> for T
+where
+    T: Value<P> + Diff,
+{
+    type Product = T::Memo;
 
-impl From<&'static str> for Class<&'static str> {
-    fn from(class: &'static str) -> Self {
-        debug_assert!(
-            !class.chars().any(|c| c == ' '),
-            "Class name cannot contain spaces, offending class: \"{class}\""
-        );
-
-        Class(class)
-    }
-}
-
-impl From<Option<&'static str>> for Class<&'static str> {
-    fn from(class: Option<&'static str>) -> Self {
-        Class::from(class.unwrap_or_default())
-    }
-}
-
-#[derive(Clone, Copy)]
-pub struct OptionalClass<'a> {
-    class: &'a str,
-    on: bool,
-}
-
-impl<'a> OptionalClass<'a> {
-    pub const fn new(class: &'a str, on: bool) -> Self {
-        OptionalClass { class, on }
+    fn build_in(self, prop: P, node: &Node) -> Self::Product {
+        self.set_prop(prop, node);
+        self.into_memo()
     }
 
-    pub const fn no_diff(self) -> NoDiff<Self> {
-        NoDiff(self)
-    }
-
-    fn get(&self) -> &'a str {
-        if self.on {
-            self.class
-        } else {
-            ""
+    fn update_in(self, prop: P, node: &Node, prod: &mut Self::Product) {
+        if self.diff(prod) {
+            self.set_prop(prop, node);
         }
     }
 }
 
-impl<'a> From<OptionalClass<'a>> for Class<OptionalClass<'a>> {
-    fn from(class: OptionalClass<'a>) -> Self {
-        Class(class)
-    }
-}
+impl<P> AttributeView<P> for String
+where
+    P: for<'a> Property<&'a str>,
+{
+    type Product = String;
 
-impl<'a> From<NoDiff<OptionalClass<'a>>> for Class<NoDiff<OptionalClass<'a>>> {
-    fn from(class: NoDiff<OptionalClass<'a>>) -> Self {
-        Class(class)
-    }
-}
-
-impl Attribute for Class<&'static str> {
-    type Abi = &'static str;
-    type Product = &'static str;
-
-    fn js(&self) -> Self::Abi {
-        self.0
+    fn build_in(self, prop: P, node: &Node) -> Self::Product {
+        self.set_prop(prop, node);
+        self
     }
 
-    fn build(self) -> Self::Product {
-        self.0
-    }
-
-    fn update(self, p: &mut Self::Product, js: &JsValue) {
-        match (self.0, *p) {
-            (new, old) if new == old => return,
-            (new, "") => util::add_class(js, new),
-            ("", old) => util::remove_class(js, old),
-            (new, old) => util::replace_class(js, old, new),
-        }
-        *p = self.0;
-    }
-}
-
-impl<'a> Attribute for Class<NoDiff<OptionalClass<'a>>> {
-    type Abi = &'a str;
-    type Product = bool;
-
-    fn js(&self) -> Self::Abi {
-        self.0.get()
-    }
-
-    fn build(self) -> Self::Product {
-        self.0.on
-    }
-
-    fn update(self, p: &mut Self::Product, js: &JsValue) {
-        match (self.0.on, *p) {
-            (true, true) | (false, false) => return,
-            (true, false) => util::add_class(js, self.0.class),
-            (false, true) => util::remove_class(js, self.0.class),
-        }
-        *p = self.0.on;
-    }
-}
-
-/// A single `className` attribute, spaces are permitted
-///
-/// <https://developer.mozilla.org/en-US/docs/Web/API/Element/className>
-pub struct ClassName<T>(T);
-
-impl From<&'static str> for ClassName<&'static str> {
-    fn from(class: &'static str) -> Self {
-        ClassName(class)
-    }
-}
-
-impl From<Option<&'static str>> for ClassName<&'static str> {
-    fn from(class: Option<&'static str>) -> Self {
-        ClassName(class.unwrap_or_default())
-    }
-}
-
-impl<'a> From<NoDiff<OptionalClass<'a>>> for ClassName<NoDiff<OptionalClass<'a>>> {
-    fn from(class: NoDiff<OptionalClass<'a>>) -> Self {
-        ClassName(class)
-    }
-}
-
-impl Attribute for ClassName<&'static str> {
-    type Abi = &'static str;
-    type Product = &'static str;
-
-    fn js(&self) -> Self::Abi {
-        self.0
-    }
-
-    fn build(self) -> Self::Product {
-        self.0
-    }
-
-    fn update(self, p: &mut Self::Product, js: &JsValue) {
-        if self.0 != *p {
-            util::set_class_name(js, self.0);
-            *p = self.0;
+    fn update_in(self, prop: P, node: &Node, prod: &mut Self::Product) {
+        if &self != prod {
+            self.set_prop(prop, node);
+            *prod = self;
         }
     }
 }
 
-impl<'a> Attribute for ClassName<NoDiff<OptionalClass<'a>>> {
-    type Abi = &'a str;
-    type Product = bool;
+// pub struct AttributeNode<A, V> {
+//     constructor: A,
+//     value: V,
+// }
 
-    fn js(&self) -> Self::Abi {
-        self.0.get()
-    }
+// macro_rules! def_attr {
+//     ($($name:ident,)*) => {
+//         $(
+//             #[doc = concat!("The `", stringify!($name) ,"` attribute constructor")]
+//             pub fn $name<V>(value: V) -> AttributeNode<impl Fn() -> Node, V> {
+//                 AttributeNode::new(util::$name, value)
+//             }
+//         )*
+//     };
+// }
 
-    fn build(self) -> Self::Product {
-        self.0.on
-    }
+// def_attr! {
+//     href,
+//     style,
+//     value,
+// }
 
-    fn update(self, p: &mut Self::Product, js: &JsValue) {
-        if self.0.on != *p {
-            util::set_class_name(js, self.0.get());
-            *p = self.0.on;
-        }
-    }
-}
+// impl<A, T> AttributeNode<A, T> {
+//     pub const fn new(constructor: A, value: T) -> Self {
+//         AttributeNode { constructor, value }
+//     }
+// }
 
-// /// The `checked` attribute for `<input>` elements
-// pub struct Checked(pub bool);
+// impl<A, T> View for AttributeNode<A, T>
+// where
+//     A: Fn() -> Node,
+//     T: IntoText + Diff + Copy,
+// {
+//     type Product = AttributeNodeProduct<T::State>;
 
-// impl Attribute for Checked {
-//     type Abi = bool;
-//     type Product = ();
+//     fn build(self) -> Self::Product {
+//         let el = Element::new((self.constructor)());
+
+//         self.value.set_attr(&el);
+//         let state = self.value.init();
+
+//         AttributeNodeProduct { state, el }
+//     }
+
+//     fn update(self, p: &mut Self::Product) {
+//         if self.value.update(&mut p.state) {
+//             self.value.set_attr(&p.el);
+//         }
+//     }
+// }
+
+// pub trait Attribute {
+//     type Abi: IntoWasmAbi;
+//     type Product: 'static;
+
+//     fn js(&self) -> Self::Abi;
+
+//     fn build(self) -> Self::Product;
+
+//     fn update(self, p: &mut Self::Product, el: &JsValue);
+// }
+
+// /// A class that interacts with `classList` property of an element
+// ///
+// /// <https://developer.mozilla.org/en-US/docs/Web/API/Element/classList>
+// #[repr(transparent)]
+// pub struct Class<T>(T);
+
+// impl From<&'static str> for Class<&'static str> {
+//     fn from(class: &'static str) -> Self {
+//         debug_assert!(
+//             !class.chars().any(|c| c == ' '),
+//             "Class name cannot contain spaces, offending class: \"{class}\""
+//         );
+
+//         Class(class)
+//     }
+// }
+
+// impl From<Option<&'static str>> for Class<&'static str> {
+//     fn from(class: Option<&'static str>) -> Self {
+//         Class::from(class.unwrap_or_default())
+//     }
+// }
+
+// #[derive(Clone, Copy)]
+// pub struct OptionalClass<'a> {
+//     class: &'a str,
+//     on: bool,
+// }
+
+// impl<'a> OptionalClass<'a> {
+//     pub const fn new(class: &'a str, on: bool) -> Self {
+//         OptionalClass { class, on }
+//     }
+
+//     pub const fn no_diff(self) -> NoDiff<Self> {
+//         NoDiff(self)
+//     }
+
+//     fn get(&self) -> &'a str {
+//         if self.on {
+//             self.class
+//         } else {
+//             ""
+//         }
+//     }
+// }
+
+// impl<'a> From<OptionalClass<'a>> for Class<OptionalClass<'a>> {
+//     fn from(class: OptionalClass<'a>) -> Self {
+//         Class(class)
+//     }
+// }
+
+// impl<'a> From<NoDiff<OptionalClass<'a>>> for Class<NoDiff<OptionalClass<'a>>> {
+//     fn from(class: NoDiff<OptionalClass<'a>>) -> Self {
+//         Class(class)
+//     }
+// }
+
+// impl Attribute for Class<&'static str> {
+//     type Abi = &'static str;
+//     type Product = &'static str;
 
 //     fn js(&self) -> Self::Abi {
 //         self.0
 //     }
 
-//     fn build(self) -> Self::Product {}
+//     fn build(self) -> Self::Product {
+//         self.0
+//     }
 
-//     fn update(self, _: &mut Self::Product, js: &JsValue) {
-//         // Checkboxes are weird because a `click` or `change` event
-//         // can affect the state without reflecting it on the product.
-//         //
-//         // Best to do the diff in the DOM directly.
-//         util::set_checked(js, self.0);
+//     fn update(self, p: &mut Self::Product, js: &JsValue) {
+//         match (self.0, *p) {
+//             (new, old) if new == old => return,
+//             (new, "") => util::add_class(js, new),
+//             ("", old) => util::remove_class(js, old),
+//             (new, old) => util::replace_class(js, old, new),
+//         }
+//         *p = self.0;
 //     }
 // }
 
-pub struct AttributeNodeProduct<V> {
-    state: V,
-    el: Element,
-}
+// impl<'a> Attribute for Class<NoDiff<OptionalClass<'a>>> {
+//     type Abi = &'a str;
+//     type Product = bool;
 
-impl<V: 'static> Mountable for AttributeNodeProduct<V> {
-    type Js = JsValue;
+//     fn js(&self) -> Self::Abi {
+//         self.0.get()
+//     }
 
-    fn el(&self) -> &Element {
-        &self.el
-    }
-}
+//     fn build(self) -> Self::Product {
+//         self.0.on
+//     }
+
+//     fn update(self, p: &mut Self::Product, js: &JsValue) {
+//         match (self.0.on, *p) {
+//             (true, true) | (false, false) => return,
+//             (true, false) => util::add_class(js, self.0.class),
+//             (false, true) => util::remove_class(js, self.0.class),
+//         }
+//         *p = self.0.on;
+//     }
+// }
+
+// pub struct AttributeNodeProduct<V> {
+//     state: V,
+//     el: Element,
+// }
+
+// impl<V: 'static> Mountable for AttributeNodeProduct<V> {
+//     type Js = JsValue;
+
+//     fn el(&self) -> &Element {
+//         &self.el
+//     }
+// }

--- a/crates/kobold/src/attribute.rs
+++ b/crates/kobold/src/attribute.rs
@@ -232,9 +232,7 @@ impl AttributeView<Class> for OptionalClass {
     }
 
     fn build_in(self, _: Class, node: &Node) -> bool {
-        if self.on {
-            util::add_class(node, self.class);
-        }
+        util::toggle_class(node, self.class, self.on);
         self.build()
     }
 

--- a/crates/kobold/src/attribute.rs
+++ b/crates/kobold/src/attribute.rs
@@ -8,24 +8,23 @@ use crate::dom::{NoDiff, Text, Property};
 use crate::util;
 use crate::{Element, Mountable, View};
 
-pub struct Attr(pub &'static str);
 pub struct Checked;
 
-impl Property<&str> for Attr {
+impl Property<&str> for &str {
     fn set(self, this: &JsValue, value: &str) {
-        util::set_attr(this, self.0, value)
+        util::set_attr(this, self, value)
     }
 }
 
-impl Property<f64> for Attr {
+impl Property<f64> for &str {
     fn set(self, this: &JsValue, value: f64) {
-        util::set_attr_num(this, self.0, value)
+        util::set_attr_num(this, self, value)
     }
 }
 
-impl Property<bool> for Attr {
+impl Property<bool> for &str {
     fn set(self, this: &JsValue, value: bool) {
-        util::set_attr_bool(this, self.0, value)
+        util::set_attr_bool(this, self, value)
     }
 }
 

--- a/crates/kobold/src/attribute.rs
+++ b/crates/kobold/src/attribute.rs
@@ -66,8 +66,7 @@ impl<A, T> AttributeNode<A, T> {
 impl<A, T> View for AttributeNode<A, T>
 where
     A: Fn() -> Node,
-    T: Text + Diff,
-    T::Updated: Text,
+    T: Text + Diff + Copy,
 {
     type Product = AttributeNodeProduct<T::State>;
 
@@ -81,7 +80,9 @@ where
     }
 
     fn update(self, p: &mut Self::Product) {
-        self.value.update(&mut p.state, |t| t.set_attr(&p.el));
+        if self.value.update(&mut p.state) {
+            self.value.set_attr(&p.el);
+        }
     }
 }
 

--- a/crates/kobold/src/diff.rs
+++ b/crates/kobold/src/diff.rs
@@ -1,5 +1,8 @@
 use std::ops::Deref;
 
+use web_sys::Node;
+
+use crate::attribute::AttributeView;
 use crate::dom::Element;
 use crate::value::IntoText;
 use crate::View;
@@ -105,6 +108,21 @@ impl<T: IntoText + Copy> View for NoDiff<T> {
     fn update(self, _: &mut Self::Product) {}
 }
 
+impl<T, P> AttributeView<P> for NoDiff<T>
+where
+    T: AttributeView<P>,
+{
+    type Product = ();
+
+    fn build(self) {}
+
+    fn build_in(self, prop: P, node: &Node) {
+        self.0.build_in(prop, node);
+    }
+
+    fn update_in(self, _: P, _: &Node, _: &mut ()) {}
+}
+
 impl<T> Diff for NoDiff<T>
 where
     T: Copy,
@@ -115,6 +133,12 @@ where
 
     fn diff(self, _: &mut ()) -> bool {
         false
+    }
+}
+
+impl AsRef<str> for NoDiff<&str> {
+    fn as_ref(&self) -> &str {
+        self.0
     }
 }
 
@@ -148,6 +172,12 @@ impl Deref for FastDiff<'_> {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}
+
+impl AsRef<str> for FastDiff<'_> {
+    fn as_ref(&self) -> &str {
         self.0
     }
 }

--- a/crates/kobold/src/diff.rs
+++ b/crates/kobold/src/diff.rs
@@ -1,0 +1,123 @@
+use crate::dom::NoDiff;
+use crate::value::FastDiff;
+
+pub trait Diff {
+    type State: 'static;
+    type Updated: ?Sized;
+
+    fn init(self) -> Self::State;
+
+    fn update(self, state: &mut Self::State, on_change: impl FnOnce(&Self::Updated));
+}
+
+impl Diff for &str {
+    type State = String;
+    type Updated = str;
+
+    fn init(self) -> String {
+        self.into()
+    }
+
+    fn update(self, state: &mut String, on_change: impl FnOnce(&str)) {
+        if self != state {
+            self.clone_into(state);
+            on_change(&self);
+        }
+    }
+}
+
+impl Diff for String {
+    type State = String;
+    type Updated = str;
+
+    fn init(self) -> String {
+        self
+    }
+
+    fn update(self, state: &mut String, on_change: impl FnOnce(&str)) {
+        if &self != state {
+            on_change(&self);
+            *state = self;
+        }
+    }
+}
+
+impl Diff for &String {
+    type State = String;
+    type Updated = str;
+
+    fn init(self) -> String {
+        self.clone()
+    }
+
+    fn update(self, state: &mut String, on_change: impl FnOnce(&str)) {
+        if self != state {
+            self.clone_into(state);
+            on_change(&self);
+        }
+    }
+}
+
+impl Diff for FastDiff<'_> {
+    type State = usize;
+    type Updated = str;
+
+    fn init(self) -> usize {
+        self.as_ptr() as _
+    }
+
+    fn update(self, state: &mut usize, on_change: impl FnOnce(&str)) {
+        if self.as_ptr() as usize != *state {
+            *state = self.as_ptr() as _;
+            on_change(&self);
+        }
+    }
+}
+
+impl<T> Diff for NoDiff<T> {
+    type State = ();
+    type Updated = T;
+
+    fn init(self) {}
+
+    fn update(self, _: &mut (), on_change: impl FnOnce(&T)) {
+        on_change(&self)
+    }
+}
+
+macro_rules! impl_diff {
+    ($($ty:ty),*) => {
+        $(
+            impl Diff for $ty {
+                type State = $ty;
+                type Updated = $ty;
+
+                fn init(self) -> $ty {
+                    self
+                }
+
+                fn update(self, state: &mut $ty, on_change: impl FnOnce(&Self)) {
+                    if self != *state {
+                        on_change(&self);
+                        *state = self;
+                    }
+                }
+            }
+
+            impl Diff for &$ty {
+                type State = $ty;
+                type Updated = $ty;
+
+                fn init(self) -> $ty {
+                    *self
+                }
+
+                fn update(self, state: &mut $ty, on_change: impl FnOnce(&$ty)) {
+                    (*self).update(state, on_change)
+                }
+            }
+        )*
+    };
+}
+
+impl_diff!(bool, u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize, f32, f64);

--- a/crates/kobold/src/diff.rs
+++ b/crates/kobold/src/diff.rs
@@ -43,6 +43,31 @@ impl Diff for &String {
     }
 }
 
+macro_rules! impl_diff {
+    ($($ty:ty),*) => {
+        $(
+            impl Diff for $ty {
+                type State = $ty;
+
+                fn init(self) -> $ty {
+                    self.into()
+                }
+
+                fn update(self, state: &mut $ty) -> bool {
+                    if self != *state {
+                        self.clone_into(state);
+                        true
+                    } else {
+                        false
+                    }
+                }
+            }
+        )*
+    };
+}
+
+impl_diff!(bool, u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize, f32, f64);
+
 impl Diff for FastDiff<'_> {
     type State = usize;
 
@@ -72,40 +97,3 @@ where
         false
     }
 }
-
-macro_rules! impl_diff {
-    ($($ty:ty),*) => {
-        $(
-            impl Diff for $ty {
-                type State = $ty;
-
-                fn init(self) -> $ty {
-                    self
-                }
-
-                fn update(self, state: &mut $ty) -> bool {
-                    if self != *state {
-                        *state = self;
-                        true
-                    } else {
-                        false
-                    }
-                }
-            }
-
-            impl Diff for &$ty {
-                type State = $ty;
-
-                fn init(self) -> $ty {
-                    *self
-                }
-
-                fn update(self, state: &mut $ty) -> bool {
-                    (*self).update(state)
-                }
-            }
-        )*
-    };
-}
-
-impl_diff!(bool, u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize, f32, f64);

--- a/crates/kobold/src/diff.rs
+++ b/crates/kobold/src/diff.rs
@@ -9,52 +9,18 @@ pub trait Diff: Copy {
     fn update(self, state: &mut Self::State) -> bool;
 }
 
-impl Diff for &str {
-    type State = String;
-
-    fn init(self) -> String {
-        self.into()
-    }
-
-    fn update(self, state: &mut String) -> bool {
-        if self != state {
-            self.clone_into(state);
-            true
-        } else {
-            false
-        }
-    }
-}
-
-impl Diff for &String {
-    type State = String;
-
-    fn init(self) -> String {
-        self.clone()
-    }
-
-    fn update(self, state: &mut String) -> bool {
-        if self != state {
-            self.clone_into(state);
-            true
-        } else {
-            false
-        }
-    }
-}
-
-macro_rules! impl_diff {
+macro_rules! impl_diff_str {
     ($($ty:ty),*) => {
         $(
             impl Diff for $ty {
-                type State = $ty;
+                type State = String;
 
-                fn init(self) -> $ty {
+                fn init(self) -> String {
                     self.into()
                 }
 
-                fn update(self, state: &mut $ty) -> bool {
-                    if self != *state {
+                fn update(self, state: &mut String) -> bool {
+                    if self != state {
                         self.clone_into(state);
                         true
                     } else {
@@ -66,6 +32,30 @@ macro_rules! impl_diff {
     };
 }
 
+macro_rules! impl_diff {
+    ($($ty:ty),*) => {
+        $(
+            impl Diff for $ty {
+                type State = $ty;
+
+                fn init(self) -> $ty {
+                    self
+                }
+
+                fn update(self, state: &mut $ty) -> bool {
+                    if self != *state {
+                        *state = self;
+                        true
+                    } else {
+                        false
+                    }
+                }
+            }
+        )*
+    };
+}
+
+impl_diff_str!(&str, &String);
 impl_diff!(bool, u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize, f32, f64);
 
 impl Diff for FastDiff<'_> {

--- a/crates/kobold/src/diff.rs
+++ b/crates/kobold/src/diff.rs
@@ -1,87 +1,75 @@
 use crate::dom::NoDiff;
 use crate::value::FastDiff;
 
-pub trait Diff {
+pub trait Diff: Copy {
     type State: 'static;
-    type Updated: ?Sized;
 
     fn init(self) -> Self::State;
 
-    fn update(self, state: &mut Self::State, on_change: impl FnOnce(&Self::Updated));
+    fn update(self, state: &mut Self::State) -> bool;
 }
 
 impl Diff for &str {
     type State = String;
-    type Updated = str;
 
     fn init(self) -> String {
         self.into()
     }
 
-    fn update(self, state: &mut String, on_change: impl FnOnce(&str)) {
+    fn update(self, state: &mut String) -> bool {
         if self != state {
             self.clone_into(state);
-            on_change(&self);
-        }
-    }
-}
-
-impl Diff for String {
-    type State = String;
-    type Updated = str;
-
-    fn init(self) -> String {
-        self
-    }
-
-    fn update(self, state: &mut String, on_change: impl FnOnce(&str)) {
-        if &self != state {
-            on_change(&self);
-            *state = self;
+            true
+        } else {
+            false
         }
     }
 }
 
 impl Diff for &String {
     type State = String;
-    type Updated = str;
 
     fn init(self) -> String {
         self.clone()
     }
 
-    fn update(self, state: &mut String, on_change: impl FnOnce(&str)) {
+    fn update(self, state: &mut String) -> bool {
         if self != state {
             self.clone_into(state);
-            on_change(&self);
+            true
+        } else {
+            false
         }
     }
 }
 
 impl Diff for FastDiff<'_> {
     type State = usize;
-    type Updated = str;
 
     fn init(self) -> usize {
         self.as_ptr() as _
     }
 
-    fn update(self, state: &mut usize, on_change: impl FnOnce(&str)) {
+    fn update(self, state: &mut usize) -> bool {
         if self.as_ptr() as usize != *state {
             *state = self.as_ptr() as _;
-            on_change(&self);
+            true
+        } else {
+            false
         }
     }
 }
 
-impl<T> Diff for NoDiff<T> {
+impl<T> Diff for NoDiff<T>
+where
+    T: Copy,
+{
     type State = ();
-    type Updated = T;
 
     fn init(self) {}
 
-    fn update(self, _: &mut (), on_change: impl FnOnce(&T)) {
-        on_change(&self)
+    fn update(self, _: &mut ()) -> bool {
+        false
     }
 }
 
@@ -90,30 +78,30 @@ macro_rules! impl_diff {
         $(
             impl Diff for $ty {
                 type State = $ty;
-                type Updated = $ty;
 
                 fn init(self) -> $ty {
                     self
                 }
 
-                fn update(self, state: &mut $ty, on_change: impl FnOnce(&Self)) {
+                fn update(self, state: &mut $ty) -> bool {
                     if self != *state {
-                        on_change(&self);
                         *state = self;
+                        true
+                    } else {
+                        false
                     }
                 }
             }
 
             impl Diff for &$ty {
                 type State = $ty;
-                type Updated = $ty;
 
                 fn init(self) -> $ty {
                     *self
                 }
 
-                fn update(self, state: &mut $ty, on_change: impl FnOnce(&$ty)) {
-                    (*self).update(state, on_change)
+                fn update(self, state: &mut $ty) -> bool {
+                    (*self).update(state)
                 }
             }
         )*

--- a/crates/kobold/src/diff.rs
+++ b/crates/kobold/src/diff.rs
@@ -139,6 +139,7 @@ impl StrExt for str {
     }
 }
 
+/// A borrowed string that's diffed by pointer instead of value.
 #[repr(transparent)]
 #[derive(Clone, Copy)]
 pub struct FastDiff<'a>(&'a str);

--- a/crates/kobold/src/dom.rs
+++ b/crates/kobold/src/dom.rs
@@ -6,8 +6,8 @@ use wasm_bindgen::JsValue;
 use web_sys::Node;
 
 use crate::util;
-use crate::Mountable;
 use crate::value::IntoText;
+use crate::Mountable;
 
 /// A settable property of a DOM `Node`
 pub trait Property<Abi> {
@@ -92,15 +92,6 @@ pub trait LargeInt: Sized + Copy + PartialEq + 'static {
     type Downcast: TryFrom<Self> + Into<f64> + IntoText;
 
     fn stringify<F: FnOnce(&str) -> R, R>(&self, f: F) -> R;
-}
-
-impl<S: LargeInt> IntoText for S {
-    fn into_text(self) -> Node {
-        match S::Downcast::try_from(self) {
-            Ok(downcast) => downcast.into_text(),
-            Err(_) => self.stringify(util::text_node),
-        }
-    }
 }
 
 impl Element {

--- a/crates/kobold/src/dom.rs
+++ b/crates/kobold/src/dom.rs
@@ -5,6 +5,7 @@ use std::ops::Deref;
 use wasm_bindgen::JsValue;
 use web_sys::Node;
 
+use crate::value::FastDiff;
 use crate::{util, Mountable, View};
 
 #[derive(Clone)]
@@ -58,12 +59,12 @@ impl Deref for Fragment {
     }
 }
 
-pub trait Text: Sized {
-    fn into_text(self) -> Node;
+pub trait Text {
+    fn to_text(&self) -> Node;
 
-    fn update(self, node: &Node);
+    fn set_text(&self, node: &Node);
 
-    fn set_attr(self, el: &JsValue);
+    fn set_attr(&self, el: &JsValue);
 
     #[inline]
     fn no_diff(self) -> NoDiff<Self>
@@ -86,11 +87,48 @@ impl<T> Deref for NoDiff<T> {
     }
 }
 
+impl<T> AsRef<T> for NoDiff<T> {
+    fn as_ref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> Text for NoDiff<T>
+where
+    T: Text,
+{
+    fn to_text(&self) -> Node {
+        self.0.to_text()
+    }
+
+    fn set_text(&self, node: &Node) {
+        self.0.set_text(node);
+    }
+
+    fn set_attr(&self, el: &JsValue) {
+        self.0.set_attr(el);
+    }
+}
+
+impl Text for FastDiff<'_> {
+    fn to_text(&self) -> Node {
+        self.0.to_text()
+    }
+
+    fn set_text(&self, node: &Node) {
+        self.0.set_text(node);
+    }
+
+    fn set_attr(&self, el: &JsValue) {
+        self.0.set_attr(el);
+    }
+}
+
 impl<T: Text + Copy> View for NoDiff<T> {
     type Product = Element;
 
     fn build(self) -> Self::Product {
-        Element::new(self.into_text())
+        Element::new(self.to_text())
     }
 
     fn update(self, _: &mut Self::Product) {}
@@ -100,49 +138,90 @@ macro_rules! impl_text {
     ($($ty:ty),* [$make:ident, $update:ident, $set:ident]) => {
         $(
             impl Text for $ty {
-                fn into_text(self) -> Node {
-                    util::$make(self as _)
+                fn to_text(&self) -> Node {
+                    util::$make(*self as _)
                 }
 
-                fn update(self, node: &Node) {
-                    util::$update(node, self as _);
+                fn set_text(&self, node: &Node) {
+                    util::$update(node, *self as _);
                 }
 
-                fn set_attr(self, el: &JsValue) {
-                    util::$set(el, self as _);
+                fn set_attr(&self, el: &JsValue) {
+                    util::$set(el, *self as _);
+                }
+            }
+
+            impl Text for &$ty {
+                fn to_text(&self) -> Node {
+                    (*self).to_text()
+                }
+
+                fn set_text(&self, node: &Node) {
+                    (*self).set_text(node)
+                }
+
+                fn set_attr(&self, el: &JsValue) {
+                    (*self).set_attr(el)
                 }
             }
         )*
     };
 }
 
-impl_text!(&str [text_node, set_text, set_attr]);
+impl Text for str {
+    fn to_text(&self) -> Node {
+        util::text_node(self)
+    }
+
+    fn set_text(&self, node: &Node) {
+        util::set_text(node, self);
+    }
+
+    fn set_attr(&self, el: &JsValue) {
+        util::set_attr(el, self);
+    }
+}
+
+impl Text for &str {
+    fn to_text(&self) -> Node {
+        (*self).to_text()
+    }
+
+    fn set_text(&self, node: &Node) {
+        (*self).set_text(node)
+    }
+
+    fn set_attr(&self, el: &JsValue) {
+        (*self).set_attr(el)
+    }
+}
+
 impl_text!(bool [text_node_bool, set_text_bool, set_attr_bool]);
 impl_text!(i8, i16, i32, isize, u8, u16, u32, usize, f32, f64 [text_node_num, set_text_num, set_attr_num]);
 
-pub trait LargeInt: Sized + Copy {
+pub trait LargeInt: Sized + Copy + PartialEq + 'static {
     type Downcast: TryFrom<Self> + Text;
 
     fn stringify<F: FnOnce(&str) -> R, R>(&self, f: F) -> R;
 }
 
 impl<S: LargeInt> Text for S {
-    fn into_text(self) -> Node {
-        match S::Downcast::try_from(self) {
-            Ok(downcast) => downcast.into_text(),
+    fn to_text(&self) -> Node {
+        match S::Downcast::try_from(*self) {
+            Ok(downcast) => downcast.to_text(),
             Err(_) => self.stringify(util::text_node),
         }
     }
 
-    fn update(self, node: &Node) {
-        match S::Downcast::try_from(self) {
-            Ok(downcast) => downcast.update(node),
+    fn set_text(&self, node: &Node) {
+        match S::Downcast::try_from(*self) {
+            Ok(downcast) => downcast.set_text(node),
             Err(_) => self.stringify(|s| util::set_text(node, s)),
         }
     }
 
-    fn set_attr(self, el: &JsValue) {
-        match S::Downcast::try_from(self) {
+    fn set_attr(&self, el: &JsValue) {
+        match S::Downcast::try_from(*self) {
             Ok(downcast) => downcast.set_attr(el),
             Err(_) => self.stringify(|s| util::set_attr(el, s)),
         }
@@ -158,7 +237,7 @@ impl Element {
     }
 
     pub fn new_text(text: impl Text) -> Self {
-        Self::new(text.into_text())
+        Self::new(text.to_text())
     }
 
     pub fn new_empty() -> Self {
@@ -175,7 +254,7 @@ impl Element {
     }
 
     pub fn set_text(&self, text: impl Text) {
-        text.update(&self.node);
+        text.set_text(&self.node);
     }
 
     pub fn anchor(&self) -> &JsValue {

--- a/crates/kobold/src/dom.rs
+++ b/crates/kobold/src/dom.rs
@@ -97,7 +97,7 @@ impl<T: Text + Copy> View for NoDiff<T> {
 }
 
 macro_rules! impl_text {
-    ($make:ident, $update:ident, $set:ident; $($ty:ty),*) => {
+    ($($ty:ty),* [$make:ident, $update:ident, $set:ident]) => {
         $(
             impl Text for $ty {
                 fn into_text(self) -> Node {
@@ -116,11 +116,9 @@ macro_rules! impl_text {
     };
 }
 
-impl_text!(text_node, set_text, set_attr; &str);
-impl_text!(text_node_bool, set_text_bool, set_attr_bool; bool);
-impl_text!(text_node_u32, set_text_u32, set_attr_u32; u8, u16, u32, usize);
-impl_text!(text_node_i32, set_text_i32, set_attr_i32; i8, i16, i32, isize);
-impl_text!(text_node_f64, set_text_f64, set_attr_f64; f32, f64);
+impl_text!(&str [text_node, set_text, set_attr]);
+impl_text!(bool [text_node_bool, set_text_bool, set_attr_bool]);
+impl_text!(i8, i16, i32, isize, u8, u16, u32, usize, f32, f64 [text_node_num, set_text_num, set_attr_num]);
 
 pub trait LargeInt: Sized + Copy {
     type Downcast: TryFrom<Self> + Text;

--- a/crates/kobold/src/dom.rs
+++ b/crates/kobold/src/dom.rs
@@ -141,8 +141,11 @@ impl<S: LargeInt> Text for S {
         }
     }
 
-    fn set_attr(self, _el: &JsValue) {
-        todo!();
+    fn set_attr(self, el: &JsValue) {
+        match S::Downcast::try_from(self) {
+            Ok(downcast) => downcast.set_attr(el),
+            Err(_) => self.stringify(|s| util::set_attr(el, s)),
+        }
     }
 }
 

--- a/crates/kobold/src/dom.rs
+++ b/crates/kobold/src/dom.rs
@@ -65,8 +65,6 @@ pub trait Text: Sized {
 
     fn set_attr(self, el: &JsValue);
 
-    fn as_js(&self) -> JsValue;
-
     #[inline]
     fn no_diff(self) -> NoDiff<Self>
     where
@@ -99,7 +97,7 @@ impl<T: Text + Copy> View for NoDiff<T> {
 }
 
 macro_rules! impl_text {
-    ($make:ident, $update:ident, $set:ident, $from:ident; $($ty:ty),*) => {
+    ($make:ident, $update:ident, $set:ident; $($ty:ty),*) => {
         $(
             impl Text for $ty {
                 fn into_text(self) -> Node {
@@ -113,21 +111,16 @@ macro_rules! impl_text {
                 fn set_attr(self, el: &JsValue) {
                     util::$set(el, self as _);
                 }
-
-                fn as_js(&self) -> JsValue {
-                    // panic!()
-                    JsValue::$from(*self as _)
-                }
             }
         )*
     };
 }
 
-impl_text!(text_node, set_text, set_attr, from_str; &str);
-impl_text!(text_node_bool, set_text_bool, set_attr_bool, from_bool; bool);
-impl_text!(text_node_u32, set_text_u32, set_attr_u32, from_f64; u8, u16, u32, usize);
-impl_text!(text_node_i32, set_text_i32, set_attr_i32, from_f64; i8, i16, i32, isize);
-impl_text!(text_node_f64, set_text_f64, set_attr_f64, from_f64; f32, f64);
+impl_text!(text_node, set_text, set_attr; &str);
+impl_text!(text_node_bool, set_text_bool, set_attr_bool; bool);
+impl_text!(text_node_u32, set_text_u32, set_attr_u32; u8, u16, u32, usize);
+impl_text!(text_node_i32, set_text_i32, set_attr_i32; i8, i16, i32, isize);
+impl_text!(text_node_f64, set_text_f64, set_attr_f64; f32, f64);
 
 pub trait LargeInt: Sized + Copy {
     type Downcast: TryFrom<Self> + Text;
@@ -152,13 +145,6 @@ impl<S: LargeInt> Text for S {
 
     fn set_attr(self, _el: &JsValue) {
         todo!();
-    }
-
-    fn as_js(&self) -> JsValue {
-        match S::Downcast::try_from(*self) {
-            Ok(downcast) => downcast.as_js(),
-            Err(_) => self.stringify(JsValue::from_str),
-        }
     }
 }
 

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -456,16 +456,10 @@ fn init_panic_hook() {
 #[macro_export]
 macro_rules! class {
     ($class:literal if $on:expr) => {
-        ::kobold::attribute::OptionalClass::new($class, $on).no_diff()
-    };
-    ($class:literal) => {
-        $class.no_diff()
+        ::kobold::attribute::OptionalClass::new($class, $on)
     };
     ($class:tt if $on:expr) => {
         ::kobold::attribute::OptionalClass::new($class, $on)
-    };
-    ($class:expr) => {
-        $class
     };
 }
 

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -305,7 +305,7 @@ pub mod prelude {
     pub use crate::dom::Text as _;
     pub use crate::event::{Event, KeyboardEvent, MouseEvent};
     pub use crate::list::ListIteratorExt as _;
-    pub use crate::value::{StrExt as _, Stringify as _};
+    pub use crate::value::StrExt as _;
     pub use crate::{bind, class};
     pub use crate::{component, view, View};
 
@@ -430,7 +430,7 @@ pub fn start(html: impl View) {
 
     let product = ManuallyDrop::new(html.build());
 
-    util::__kobold_start(product.js());
+    util::append_body(product.js());
 }
 
 fn init_panic_hook() {

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -302,6 +302,7 @@ pub mod stateful;
 /// use kobold::prelude::*;
 /// ```
 pub mod prelude {
+    pub use crate::dom::Text as _;
     pub use crate::event::{Event, KeyboardEvent, MouseEvent};
     pub use crate::list::ListIteratorExt as _;
     pub use crate::value::{StrExt as _, Stringify as _};

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -13,7 +13,7 @@
 //! Kobold keeps track of the DOM node references for these expressions.
 //!
 //! Since the exact types the expressions evaluate to are known to the Rust compiler, update calls can diff them by
-//! value ([or pointer](crate::value::StrExt::fast_diff)) and surgically update the DOM should they change. Changing a
+//! value ([or pointer](crate::diff::StrExt::fast_diff)) and surgically update the DOM should they change. Changing a
 //! string or an integer only updates the exact [`Text` node](https://developer.mozilla.org/en-US/docs/Web/API/Text)
 //! that string or integer was rendered to.
 //!
@@ -291,7 +291,10 @@ pub mod dom;
 pub mod event;
 pub mod list;
 pub mod util;
-pub mod value;
+
+mod value;
+
+pub use value::Value;
 
 #[cfg(feature = "stateful")]
 pub mod stateful;
@@ -303,10 +306,9 @@ pub mod stateful;
 /// use kobold::prelude::*;
 /// ```
 pub mod prelude {
-    pub use crate::dom::Text as _;
     pub use crate::event::{Event, KeyboardEvent, MouseEvent};
     pub use crate::list::ListIteratorExt as _;
-    pub use crate::value::StrExt as _;
+    pub use crate::diff::StrExt as _;
     pub use crate::{bind, class};
     pub use crate::{component, view, View};
 

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -286,6 +286,7 @@ use wasm_bindgen::{JsCast, JsValue};
 
 pub mod attribute;
 pub mod branching;
+pub mod diff;
 pub mod dom;
 pub mod event;
 pub mod list;

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -306,9 +306,9 @@ pub mod stateful;
 /// use kobold::prelude::*;
 /// ```
 pub mod prelude {
+    pub use crate::diff::{Diff as _, StrExt as _};
     pub use crate::event::{Event, KeyboardEvent, MouseEvent};
     pub use crate::list::ListIteratorExt as _;
-    pub use crate::diff::StrExt as _;
     pub use crate::{bind, class};
     pub use crate::{component, view, View};
 

--- a/crates/kobold/src/util.rs
+++ b/crates/kobold/src/util.rs
@@ -4,7 +4,7 @@ use web_sys::Node;
 use crate::dom::Element;
 use crate::View;
 
-pub struct Static<F>(pub F);
+pub struct Static<F = fn() -> Node>(pub F);
 
 impl<F> View for Static<F>
 where
@@ -37,8 +37,23 @@ extern "C" {
     pub(crate) fn __kobold_fragment_drop(f: &Node);
 
     pub(crate) fn __kobold_text_node(t: &str) -> Node;
-
+    #[wasm_bindgen(js_name = "__kobold_text_node_coerce")]
+    pub(crate) fn __kobold_text_node_uint(t: u32) -> Node;
+    #[wasm_bindgen(js_name = "__kobold_text_node_coerce")]
+    pub(crate) fn __kobold_text_node_int(t: i32) -> Node;
+    #[wasm_bindgen(js_name = "__kobold_text_node_coerce")]
+    pub(crate) fn __kobold_text_node_float(t: f64) -> Node;
+    #[wasm_bindgen(js_name = "__kobold_text_node_coerce")]
+    pub(crate) fn __kobold_text_node_bool(t: bool) -> Node;
     pub(crate) fn __kobold_update_text(node: &Node, t: &str);
+    #[wasm_bindgen(js_name = "__kobold_update_text_coerce")]
+    pub(crate) fn __kobold_update_text_uint(node: &Node, t: u32);
+    #[wasm_bindgen(js_name = "__kobold_update_text_coerce")]
+    pub(crate) fn __kobold_update_text_int(node: &Node, t: i32);
+    #[wasm_bindgen(js_name = "__kobold_update_text_coerce")]
+    pub(crate) fn __kobold_update_text_float(node: &Node, t: f64);
+    #[wasm_bindgen(js_name = "__kobold_update_text_coerce")]
+    pub(crate) fn __kobold_update_text_bool(node: &Node, t: bool);
 
     pub(crate) fn __kobold_attr(name: &str, value: &str) -> Node;
     pub(crate) fn __kobold_attr_class(value: &str) -> Node;

--- a/crates/kobold/src/util.rs
+++ b/crates/kobold/src/util.rs
@@ -57,11 +57,11 @@ extern "C" {
 
     // `set_attr` variants ----------------
 
-    #[wasm_bindgen(js_name = "__kobold_set_attr_value")]
+    #[wasm_bindgen(js_name = "__kobold_set_attr")]
     pub(crate) fn set_attr(el: &JsValue, a: &str, v: &str);
-    #[wasm_bindgen(js_name = "__kobold_set_attr_value")]
+    #[wasm_bindgen(js_name = "__kobold_set_attr")]
     pub(crate) fn set_attr_num(el: &JsValue, a: &str, v: f64);
-    #[wasm_bindgen(js_name = "__kobold_set_attr_value")]
+    #[wasm_bindgen(js_name = "__kobold_set_attr")]
     pub(crate) fn set_attr_bool(el: &JsValue, a: &str, v: bool);
 
     // provided attribute setters ----------------

--- a/crates/kobold/src/util.rs
+++ b/crates/kobold/src/util.rs
@@ -49,20 +49,29 @@ extern "C" {
     // `set_text` variants ----------------
 
     #[wasm_bindgen(js_name = "__kobold_set_text")]
-    pub(crate) fn set_text(node: &Node, t: &str);
+    pub(crate) fn set_text(el: &JsValue, t: &str);
     #[wasm_bindgen(js_name = "__kobold_set_text")]
-    pub(crate) fn set_text_num(node: &Node, t: f64);
+    pub(crate) fn set_text_num(el: &JsValue, t: f64);
     #[wasm_bindgen(js_name = "__kobold_set_text")]
-    pub(crate) fn set_text_bool(node: &Node, t: bool);
+    pub(crate) fn set_text_bool(el: &JsValue, t: bool);
 
     // `set_attr` variants ----------------
 
-    #[wasm_bindgen(js_name = "__kobold_set_attr")]
-    pub(crate) fn set_attr(el: &JsValue, v: &str);
-    #[wasm_bindgen(js_name = "__kobold_set_attr")]
-    pub(crate) fn set_attr_num(el: &JsValue, v: f64);
-    #[wasm_bindgen(js_name = "__kobold_set_attr")]
-    pub(crate) fn set_attr_bool(el: &JsValue, v: bool);
+    #[wasm_bindgen(js_name = "__kobold_set_attr_value")]
+    pub(crate) fn set_attr(el: &JsValue, a: &str, v: &str);
+    #[wasm_bindgen(js_name = "__kobold_set_attr_value")]
+    pub(crate) fn set_attr_num(el: &JsValue, a: &str, v: f64);
+    #[wasm_bindgen(js_name = "__kobold_set_attr_value")]
+    pub(crate) fn set_attr_bool(el: &JsValue, a: &str, v: bool);
+
+    // `set_attr_value` variants ----------------
+
+    #[wasm_bindgen(js_name = "__kobold_set_attr_value")]
+    pub(crate) fn set_attr_value(el: &JsValue, v: &str);
+    #[wasm_bindgen(js_name = "__kobold_set_attr_value")]
+    pub(crate) fn set_attr_value_num(el: &JsValue, v: f64);
+    #[wasm_bindgen(js_name = "__kobold_set_attr_value")]
+    pub(crate) fn set_attr_value_bool(el: &JsValue, v: bool);
 
     // provided attribute constructors ----------------
 

--- a/crates/kobold/src/util.rs
+++ b/crates/kobold/src/util.rs
@@ -28,13 +28,13 @@ extern "C" {
     pub(crate) fn text_node(t: &str) -> Node;
 
     #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
-    pub(crate) fn text_node_uint(t: u32) -> Node;
+    pub(crate) fn text_node_u32(t: u32) -> Node;
 
     #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
-    pub(crate) fn text_node_int(t: i32) -> Node;
+    pub(crate) fn text_node_i32(t: i32) -> Node;
 
     #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
-    pub(crate) fn text_node_float(t: f64) -> Node;
+    pub(crate) fn text_node_f64(t: f64) -> Node;
 
     #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
     pub(crate) fn text_node_bool(t: bool) -> Node;
@@ -42,8 +42,6 @@ extern "C" {
 
 #[wasm_bindgen(module = "/js/util.js")]
 extern "C" {
-    pub(crate) fn __kobold_start(node: &JsValue);
-
     pub(crate) fn __kobold_append(parent: &Node, child: &JsValue);
     pub(crate) fn __kobold_before(node: &Node, insert: &JsValue);
     pub(crate) fn __kobold_unmount(node: &JsValue);
@@ -57,26 +55,51 @@ extern "C" {
     pub(crate) fn __kobold_fragment_replace(f: &Node, new: &JsValue);
     pub(crate) fn __kobold_fragment_drop(f: &Node);
 
-    #[wasm_bindgen(js_name = "__kobold_update_text")]
-    pub(crate) fn update_text(node: &Node, t: &str);
-    #[wasm_bindgen(js_name = "__kobold_update_text")]
-    pub(crate) fn update_text_uint(node: &Node, t: u32);
-    #[wasm_bindgen(js_name = "__kobold_update_text")]
-    pub(crate) fn update_text_int(node: &Node, t: i32);
-    #[wasm_bindgen(js_name = "__kobold_update_text")]
-    pub(crate) fn update_text_float(node: &Node, t: f64);
-    #[wasm_bindgen(js_name = "__kobold_update_text")]
-    pub(crate) fn update_text_bool(node: &Node, t: bool);
+    // `set_text` variants ----------------
 
-    pub(crate) fn __kobold_attr(name: &str, value: &str) -> Node;
-    pub(crate) fn __kobold_attr_class(value: &str) -> Node;
-    pub(crate) fn __kobold_attr_style(value: &str) -> Node;
-    pub(crate) fn __kobold_attr_set(node: &JsValue, name: &str, value: &str) -> Node;
-    pub(crate) fn __kobold_attr_update(node: &Node, value: &str);
+    #[wasm_bindgen(js_name = "__kobold_set_text")]
+    pub(crate) fn set_text(node: &Node, t: &str);
+    #[wasm_bindgen(js_name = "__kobold_set_text")]
+    pub(crate) fn set_text_u32(node: &Node, t: u32);
+    #[wasm_bindgen(js_name = "__kobold_set_text")]
+    pub(crate) fn set_text_i32(node: &Node, t: i32);
+    #[wasm_bindgen(js_name = "__kobold_set_text")]
+    pub(crate) fn set_text_f64(node: &Node, t: f64);
+    #[wasm_bindgen(js_name = "__kobold_set_text")]
+    pub(crate) fn set_text_bool(node: &Node, t: bool);
 
-    pub(crate) fn __kobold_attr_checked_set(el: &JsValue, value: bool);
-    pub(crate) fn __kobold_class_set(el: &JsValue, value: &str);
-    pub(crate) fn __kobold_class_add(el: &JsValue, value: &str);
-    pub(crate) fn __kobold_class_remove(el: &JsValue, value: &str);
-    pub(crate) fn __kobold_class_replace(el: &JsValue, old: &str, value: &str);
+    // `set_attr` variants ----------------
+
+    #[wasm_bindgen(js_name = "__kobold_set_attr")]
+    pub(crate) fn set_attr(el: &JsValue, v: &str);
+    #[wasm_bindgen(js_name = "__kobold_set_attr")]
+    pub(crate) fn set_attr_u32(el: &JsValue, v: u32);
+    #[wasm_bindgen(js_name = "__kobold_set_attr")]
+    pub(crate) fn set_attr_i32(el: &JsValue, v: i32);
+    #[wasm_bindgen(js_name = "__kobold_set_attr")]
+    pub(crate) fn set_attr_f64(el: &JsValue, v: f64);
+    #[wasm_bindgen(js_name = "__kobold_set_attr")]
+    pub(crate) fn set_attr_bool(el: &JsValue, v: bool);
+
+    // provided attribute constructors ----------------
+
+    #[wasm_bindgen(js_name = "__kobold_attr_href")]
+    pub(crate) fn href() -> Node;
+    #[wasm_bindgen(js_name = "__kobold_attr_style")]
+    pub(crate) fn style() -> Node;
+    #[wasm_bindgen(js_name = "__kobold_attr_value")]
+    pub(crate) fn value() -> Node;
+
+    // ----------------
+
+    #[wasm_bindgen(js_name = "__kobold_set_checked")]
+    pub(crate) fn set_checked(el: &JsValue, value: bool);
+    #[wasm_bindgen(js_name = "__kobold_set_class_name")]
+    pub(crate) fn set_class_name(el: &JsValue, value: &str);
+    #[wasm_bindgen(js_name = "__kobold_add_class")]
+    pub(crate) fn add_class(el: &JsValue, value: &str);
+    #[wasm_bindgen(js_name = "__kobold_remove_class")]
+    pub(crate) fn remove_class(el: &JsValue, value: &str);
+    #[wasm_bindgen(js_name = "__kobold_replace_class")]
+    pub(crate) fn replace_class(el: &JsValue, old: &str, value: &str);
 }

--- a/crates/kobold/src/util.rs
+++ b/crates/kobold/src/util.rs
@@ -19,6 +19,27 @@ where
     fn update(self, _: &mut Element) {}
 }
 
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = ["document", "body"], js_name = appendChild)]
+    pub(crate) fn append_body(node: &JsValue);
+
+    #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
+    pub(crate) fn text_node(t: &str) -> Node;
+
+    #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
+    pub(crate) fn text_node_uint(t: u32) -> Node;
+
+    #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
+    pub(crate) fn text_node_int(t: i32) -> Node;
+
+    #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
+    pub(crate) fn text_node_float(t: f64) -> Node;
+
+    #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
+    pub(crate) fn text_node_bool(t: bool) -> Node;
+}
+
 #[wasm_bindgen(module = "/js/util.js")]
 extern "C" {
     pub(crate) fn __kobold_start(node: &JsValue);
@@ -36,24 +57,16 @@ extern "C" {
     pub(crate) fn __kobold_fragment_replace(f: &Node, new: &JsValue);
     pub(crate) fn __kobold_fragment_drop(f: &Node);
 
-    pub(crate) fn __kobold_text_node(t: &str) -> Node;
-    #[wasm_bindgen(js_name = "__kobold_text_node_coerce")]
-    pub(crate) fn __kobold_text_node_uint(t: u32) -> Node;
-    #[wasm_bindgen(js_name = "__kobold_text_node_coerce")]
-    pub(crate) fn __kobold_text_node_int(t: i32) -> Node;
-    #[wasm_bindgen(js_name = "__kobold_text_node_coerce")]
-    pub(crate) fn __kobold_text_node_float(t: f64) -> Node;
-    #[wasm_bindgen(js_name = "__kobold_text_node_coerce")]
-    pub(crate) fn __kobold_text_node_bool(t: bool) -> Node;
-    pub(crate) fn __kobold_update_text(node: &Node, t: &str);
-    #[wasm_bindgen(js_name = "__kobold_update_text_coerce")]
-    pub(crate) fn __kobold_update_text_uint(node: &Node, t: u32);
-    #[wasm_bindgen(js_name = "__kobold_update_text_coerce")]
-    pub(crate) fn __kobold_update_text_int(node: &Node, t: i32);
-    #[wasm_bindgen(js_name = "__kobold_update_text_coerce")]
-    pub(crate) fn __kobold_update_text_float(node: &Node, t: f64);
-    #[wasm_bindgen(js_name = "__kobold_update_text_coerce")]
-    pub(crate) fn __kobold_update_text_bool(node: &Node, t: bool);
+    #[wasm_bindgen(js_name = "__kobold_update_text")]
+    pub(crate) fn update_text(node: &Node, t: &str);
+    #[wasm_bindgen(js_name = "__kobold_update_text")]
+    pub(crate) fn update_text_uint(node: &Node, t: u32);
+    #[wasm_bindgen(js_name = "__kobold_update_text")]
+    pub(crate) fn update_text_int(node: &Node, t: i32);
+    #[wasm_bindgen(js_name = "__kobold_update_text")]
+    pub(crate) fn update_text_float(node: &Node, t: f64);
+    #[wasm_bindgen(js_name = "__kobold_update_text")]
+    pub(crate) fn update_text_bool(node: &Node, t: bool);
 
     pub(crate) fn __kobold_attr(name: &str, value: &str) -> Node;
     pub(crate) fn __kobold_attr_class(value: &str) -> Node;

--- a/crates/kobold/src/util.rs
+++ b/crates/kobold/src/util.rs
@@ -49,11 +49,11 @@ extern "C" {
     // `set_text` variants ----------------
 
     #[wasm_bindgen(js_name = "__kobold_set_text")]
-    pub(crate) fn set_text(el: &JsValue, t: &str);
+    pub(crate) fn set_text(el: &Node, t: &str);
     #[wasm_bindgen(js_name = "__kobold_set_text")]
-    pub(crate) fn set_text_num(el: &JsValue, t: f64);
+    pub(crate) fn set_text_num(el: &Node, t: f64);
     #[wasm_bindgen(js_name = "__kobold_set_text")]
-    pub(crate) fn set_text_bool(el: &JsValue, t: bool);
+    pub(crate) fn set_text_bool(el: &Node, t: bool);
 
     // `set_attr` variants ----------------
 
@@ -64,30 +64,23 @@ extern "C" {
     #[wasm_bindgen(js_name = "__kobold_set_attr_value")]
     pub(crate) fn set_attr_bool(el: &JsValue, a: &str, v: bool);
 
-    // `set_attr_value` variants ----------------
+    // provided attribute setters ----------------
 
-    #[wasm_bindgen(js_name = "__kobold_set_attr_value")]
-    pub(crate) fn set_attr_value(el: &JsValue, v: &str);
-    #[wasm_bindgen(js_name = "__kobold_set_attr_value")]
-    pub(crate) fn set_attr_value_num(el: &JsValue, v: f64);
-    #[wasm_bindgen(js_name = "__kobold_set_attr_value")]
-    pub(crate) fn set_attr_value_bool(el: &JsValue, v: bool);
-
-    // provided attribute constructors ----------------
-
-    #[wasm_bindgen(js_name = "__kobold_attr_href")]
-    pub(crate) fn href() -> Node;
-    #[wasm_bindgen(js_name = "__kobold_attr_style")]
-    pub(crate) fn style() -> Node;
-    #[wasm_bindgen(js_name = "__kobold_attr_value")]
-    pub(crate) fn value() -> Node;
+    #[wasm_bindgen(js_name = "__kobold_checked")]
+    pub(crate) fn checked(el: &Node, value: bool);
+    #[wasm_bindgen(js_name = "__kobold_class_name")]
+    pub(crate) fn class_name(el: &Node, value: &str);
+    #[wasm_bindgen(js_name = "__kobold_href")]
+    pub(crate) fn href(el: &Node, value: &str);
+    #[wasm_bindgen(js_name = "__kobold_style")]
+    pub(crate) fn style(el: &Node, value: &str);
+    #[wasm_bindgen(js_name = "__kobold_value")]
+    pub(crate) fn value(el: &Node, value: &str);
+    #[wasm_bindgen(js_name = "__kobold_value")]
+    pub(crate) fn value_num(el: &Node, value: f64);
 
     // ----------------
 
-    #[wasm_bindgen(js_name = "__kobold_set_checked")]
-    pub(crate) fn set_checked(el: &JsValue, value: bool);
-    #[wasm_bindgen(js_name = "__kobold_set_class_name")]
-    pub(crate) fn set_class_name(el: &JsValue, value: &str);
     #[wasm_bindgen(js_name = "__kobold_add_class")]
     pub(crate) fn add_class(el: &JsValue, value: &str);
     #[wasm_bindgen(js_name = "__kobold_remove_class")]

--- a/crates/kobold/src/util.rs
+++ b/crates/kobold/src/util.rs
@@ -67,24 +67,26 @@ extern "C" {
     // provided attribute setters ----------------
 
     #[wasm_bindgen(js_name = "__kobold_checked")]
-    pub(crate) fn checked(el: &Node, value: bool);
+    pub(crate) fn checked(node: &Node, value: bool);
     #[wasm_bindgen(js_name = "__kobold_class_name")]
-    pub(crate) fn class_name(el: &Node, value: &str);
+    pub(crate) fn class_name(node: &Node, value: &str);
     #[wasm_bindgen(js_name = "__kobold_href")]
-    pub(crate) fn href(el: &Node, value: &str);
+    pub(crate) fn href(node: &Node, value: &str);
     #[wasm_bindgen(js_name = "__kobold_style")]
-    pub(crate) fn style(el: &Node, value: &str);
+    pub(crate) fn style(node: &Node, value: &str);
     #[wasm_bindgen(js_name = "__kobold_value")]
-    pub(crate) fn value(el: &Node, value: &str);
+    pub(crate) fn value(node: &Node, value: &str);
     #[wasm_bindgen(js_name = "__kobold_value")]
-    pub(crate) fn value_num(el: &Node, value: f64);
+    pub(crate) fn value_num(node: &Node, value: f64);
 
     // ----------------
 
     #[wasm_bindgen(js_name = "__kobold_add_class")]
-    pub(crate) fn add_class(el: &JsValue, value: &str);
+    pub(crate) fn add_class(node: &Node, value: &str);
     #[wasm_bindgen(js_name = "__kobold_remove_class")]
-    pub(crate) fn remove_class(el: &JsValue, value: &str);
+    pub(crate) fn remove_class(node: &Node, value: &str);
     #[wasm_bindgen(js_name = "__kobold_replace_class")]
-    pub(crate) fn replace_class(el: &JsValue, old: &str, value: &str);
+    pub(crate) fn replace_class(node: &Node, old: &str, value: &str);
+    #[wasm_bindgen(js_name = "__kobold_toggle_class")]
+    pub(crate) fn toggle_class(node: &Node, class: &str, value: bool);
 }

--- a/crates/kobold/src/util.rs
+++ b/crates/kobold/src/util.rs
@@ -23,19 +23,10 @@ where
 extern "C" {
     #[wasm_bindgen(js_namespace = ["document", "body"], js_name = appendChild)]
     pub(crate) fn append_body(node: &JsValue);
-
     #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
     pub(crate) fn text_node(t: &str) -> Node;
-
     #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
-    pub(crate) fn text_node_u32(t: u32) -> Node;
-
-    #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
-    pub(crate) fn text_node_i32(t: i32) -> Node;
-
-    #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
-    pub(crate) fn text_node_f64(t: f64) -> Node;
-
+    pub(crate) fn text_node_num(t: f64) -> Node;
     #[wasm_bindgen(js_namespace = document, js_name = createTextNode)]
     pub(crate) fn text_node_bool(t: bool) -> Node;
 }
@@ -60,11 +51,7 @@ extern "C" {
     #[wasm_bindgen(js_name = "__kobold_set_text")]
     pub(crate) fn set_text(node: &Node, t: &str);
     #[wasm_bindgen(js_name = "__kobold_set_text")]
-    pub(crate) fn set_text_u32(node: &Node, t: u32);
-    #[wasm_bindgen(js_name = "__kobold_set_text")]
-    pub(crate) fn set_text_i32(node: &Node, t: i32);
-    #[wasm_bindgen(js_name = "__kobold_set_text")]
-    pub(crate) fn set_text_f64(node: &Node, t: f64);
+    pub(crate) fn set_text_num(node: &Node, t: f64);
     #[wasm_bindgen(js_name = "__kobold_set_text")]
     pub(crate) fn set_text_bool(node: &Node, t: bool);
 
@@ -73,11 +60,7 @@ extern "C" {
     #[wasm_bindgen(js_name = "__kobold_set_attr")]
     pub(crate) fn set_attr(el: &JsValue, v: &str);
     #[wasm_bindgen(js_name = "__kobold_set_attr")]
-    pub(crate) fn set_attr_u32(el: &JsValue, v: u32);
-    #[wasm_bindgen(js_name = "__kobold_set_attr")]
-    pub(crate) fn set_attr_i32(el: &JsValue, v: i32);
-    #[wasm_bindgen(js_name = "__kobold_set_attr")]
-    pub(crate) fn set_attr_f64(el: &JsValue, v: f64);
+    pub(crate) fn set_attr_num(el: &JsValue, v: f64);
     #[wasm_bindgen(js_name = "__kobold_set_attr")]
     pub(crate) fn set_attr_bool(el: &JsValue, v: bool);
 

--- a/crates/kobold/src/value.rs
+++ b/crates/kobold/src/value.rs
@@ -10,112 +10,37 @@ use crate::stateful::{self, Then};
 use crate::{Element, Mountable, View};
 
 pub trait Value<P> {
-    type Product: 'static;
-
-    fn set_build(self, el: &JsValue, prop: P) -> Self::Product;
-
-    fn set_update(self, el: &JsValue, prop: P, prod: &mut Self::Product);
+    fn set_prop(self, el: &JsValue, prop: P);
 }
 
-impl<P> Value<P> for String
-where
-    P: for<'a> Property<&'a str>,
-{
-    type Product = String;
-
-    fn set_build(self, el: &JsValue, prop: P) -> Self::Product {
-        prop.set(el, &self);
-
-        self
-    }
-
-    fn set_update(self, el: &JsValue, prop: P, prod: &mut Self::Product) {
-        if &self != prod {
-            prop.set(el, &self);
-            *prod = self;
-        }
-    }
-}
-
-macro_rules! impl_value_str {
-    ($($ty:ty),*) => {
-        $(
-            impl<P> Value<P> for $ty
-            where
-                P: for<'a> Property<&'a str>,
-            {
-                type Product = String;
-
-                fn set_build(self, el: &JsValue, prop: P) -> Self::Product {
-                    prop.set(el, self);
-
-                    self.into()
-                }
-
-                fn set_update(self, el: &JsValue, prop: P, prod: &mut Self::Product) {
-                    if self != prod {
-                        self.clone_into(prod);
-                        prop.set(el, self)
-                    }
-                }
-            }
-        )*
-    };
-}
-
-macro_rules! impl_value_copy {
+macro_rules! impl_value {
     ($abi:ty: $($ty:ty),*) => {
         $(
             impl<P> Value<P> for $ty
             where
-                P: Property<$abi>,
+                P: for<'a> Property<$abi>,
             {
-                type Product = $ty;
-
-                fn set_build(self, el: &JsValue, prop: P) -> Self::Product {
+                fn set_prop(self, el: &JsValue, prop: P) {
                     prop.set(el, self as _);
-
-                    self
-                }
-
-                fn set_update(self, el: &JsValue, prop: P, prod: &mut Self::Product) {
-                    if self != *prod {
-                        *prod = self;
-                        prop.set(el, self as _)
-                    }
                 }
             }
         )*
     };
 }
 
-impl_value_str!(&str, &String);
-impl_value_copy!(bool: bool);
-impl_value_copy!(f64: u8, u16, u32, usize, i8, i16, i32, isize);
+impl_value!(&'a str: &str, &String);
+impl_value!(bool: bool);
+impl_value!(f64: u8, u16, u32, usize, i8, i16, i32, isize);
 
 impl<P, I> Value<P> for I
 where
     I: LargeInt,
     P: Property<f64> + for<'a> Property<&'a str>,
 {
-    type Product = Self;
-
-    fn set_build(self, el: &JsValue, prop: P) -> Self::Product {
+    fn set_prop(self, el: &JsValue, prop: P) {
         match <Self as LargeInt>::Downcast::try_from(self) {
             Ok(int) => prop.set(el, int.into()),
             Err(_) => self.stringify(|s| prop.set(el, s)),
-        }
-
-        self
-    }
-
-    fn set_update(self, el: &JsValue, prop: P, prod: &mut Self::Product) {
-        if self != *prod {
-            *prod = self;
-            match <Self as LargeInt>::Downcast::try_from(self) {
-                Ok(int) => prop.set(el, int.into()),
-                Err(_) => self.stringify(|s| prop.set(el, s)),
-            }
         }
     }
 }

--- a/crates/kobold/src/value.rs
+++ b/crates/kobold/src/value.rs
@@ -141,3 +141,35 @@ macro_rules! impl_text_view {
 
 impl_text_view!(&str, &String, FastDiff<'_>);
 impl_text_view!(bool, u8, u16, u32, u64, u128, usize, isize, i8, i16, i32, i64, i128, f32, f64);
+
+impl<'a> View for &&'a str {
+    type Product = <&'a str as View>::Product;
+
+    fn build(self) -> Self::Product {
+        (*self).build()
+    }
+
+    fn update(self, p: &mut Self::Product) {
+        (*self).update(p)
+    }
+}
+
+macro_rules! impl_ref_view {
+    ($($ty:ty),*) => {
+        $(
+            impl View for &$ty {
+                type Product = <$ty as View>::Product;
+
+                fn build(self) -> Self::Product {
+                    (*self).build()
+                }
+
+                fn update(self, p: &mut Self::Product) {
+                    (*self).update(p)
+                }
+            }
+        )*
+    };
+}
+
+impl_ref_view!(bool, u8, u16, u32, u64, u128, usize, isize, i8, i16, i32, i64, i128, f32, f64);

--- a/crates/kobold/src/value.rs
+++ b/crates/kobold/src/value.rs
@@ -234,6 +234,7 @@ impl StrExt for str {
 }
 
 #[repr(transparent)]
+#[derive(Clone, Copy)]
 pub struct FastDiff<'a>(pub(crate) &'a str);
 
 impl AsRef<str> for FastDiff<'_> {

--- a/crates/kobold_macros/src/gen.rs
+++ b/crates/kobold_macros/src/gen.rs
@@ -15,9 +15,9 @@ mod transient;
 
 pub use element::JsElement;
 pub use fragment::{append, JsFragment};
-pub use transient::{Abi, Field, JsArgument, JsFnName, JsFunction, JsModule, JsString, Transient};
-
-use self::transient::JsAttrConstructor;
+pub use transient::{
+    Field, FieldKind, JsArgument, JsFnName, JsFunction, JsModule, JsString, Transient,
+};
 
 // Short string for auto-generated variable names
 pub type Short = ArrayString<4>;
@@ -57,48 +57,54 @@ impl Generator {
         self.out.js_type = Some(ty);
     }
 
-    fn add_expression(&mut self, value: TokenStream) -> Short {
+    fn add_field(&mut self, value: TokenStream) -> &mut Field {
         let name = self.names.next();
 
-        self.out.fields.push(Field::View { name, value });
-
-        name
+        self.out.fields.push(Field::new(name, value));
+        self.out.fields.last_mut().unwrap()
     }
 
-    fn add_attribute(&mut self, el: Short, abi: Abi, value: TokenStream) -> Short {
-        let name = self.names.next();
+    // fn add_expression(&mut self, value: TokenStream) -> Short {
+    //     let name = self.names.next();
 
-        self.out.fields.push(Field::Attribute {
-            name,
-            el,
-            abi,
-            value,
-        });
+    //     self.out.fields.push(Field::view(name, value));
 
-        name
-    }
+    //     name
+    // }
 
-    fn attribute_constructor(&mut self, attr: &str) -> JsFnName {
-        use std::hash::Hasher;
+    // fn add_attribute(&mut self, el: Short, abi: Abi, value: TokenStream) -> Short {
+    //     let name = self.names.next();
 
-        let mut hasher = fnv::FnvHasher::default();
-        attr.hash(&mut hasher);
+    //     self.out.fields.push(Field {
+    //         name,
+    //         value,
+    //         kind: FieldKind::Attribute { el, abi }
+    //     });
 
-        let hash = hasher.finish();
-        let name = JsFnName::try_from(format_args!("__attr_{hash:016x}")).unwrap();
+    //     name
+    // }
 
-        let _ = write!(
-            self.out.js.code,
-            "export function {name}() {{\
-                \nreturn document.createAttribute(\"{attr}\");\
-            \n}}\n\
-            "
-        );
+    // fn attribute_constructor(&mut self, attr: &str) -> JsFnName {
+    //     use std::hash::Hasher;
 
-        self.out.js.attr_constructors.push(JsAttrConstructor(name));
+    //     let mut hasher = fnv::FnvHasher::default();
+    //     attr.hash(&mut hasher);
 
-        name
-    }
+    //     let hash = hasher.finish();
+    //     let name = JsFnName::try_from(format_args!("__attr_{hash:016x}")).unwrap();
+
+    //     let _ = write!(
+    //         self.out.js.code,
+    //         "export function {name}() {{\
+    //             \nreturn document.createAttribute(\"{attr}\");\
+    //         \n}}\n\
+    //         "
+    //     );
+
+    //     self.out.js.attr_constructors.push(JsAttrConstructor(name));
+
+    //     name
+    // }
 
     fn hoist(&mut self, node: DomNode) -> Option<JsFnName> {
         use std::hash::Hasher;
@@ -171,9 +177,7 @@ trait IntoGenerator {
 
 impl IntoGenerator for Expression {
     fn into_gen(self, gen: &mut Generator) -> DomNode {
-        let name = gen.add_expression(self.stream);
-
-        DomNode::Variable(name)
+        DomNode::Variable(gen.add_field(self.stream).name)
     }
 }
 

--- a/crates/kobold_macros/src/gen/component.rs
+++ b/crates/kobold_macros/src/gen/component.rs
@@ -52,7 +52,7 @@ impl IntoGenerator for Component {
         let name = gen.names.next();
         let value = self.into_expression();
 
-        gen.out.fields.push(Field::View { name, value });
+        gen.out.fields.push(Field::new(name, value));
 
         DomNode::Variable(name)
     }

--- a/crates/kobold_macros/src/gen/element.rs
+++ b/crates/kobold_macros/src/gen/element.rs
@@ -129,10 +129,21 @@ impl IntoGenerator for HtmlElement {
                         writeln!(el, "{var}.{attr}={value};");
 
                         JsArgument::with_abi(value, "bool")
+                    } else if provided_attr(attr) {
+                        let value = gen.add_expression(call(
+                            format_args!("::kobold::attribute::{attr}"),
+                            expr.stream,
+                        ));
+
+                        writeln!(el, "{var}.setAttributeNode({value});");
+
+                        JsArgument::new(value)
                     } else {
+                        let attr_fn = gen.attribute_constructor(attr);
+
                         let value = gen.add_expression(call(
                             "::kobold::attribute::AttributeNode::new",
-                            (string(attr), ',', expr.stream),
+                            (ident(&attr_fn), ',', expr.stream),
                         ));
 
                         writeln!(el, "{var}.setAttributeNode({value});");
@@ -151,6 +162,16 @@ impl IntoGenerator for HtmlElement {
         }
 
         DomNode::Element(el)
+    }
+}
+
+#[rustfmt::skip]
+fn provided_attr(attr: &str) -> bool {
+    match attr {
+        "href"
+        | "style"
+        | "value" => true,
+        _ => false,
     }
 }
 

--- a/crates/kobold_macros/src/gen/transient.rs
+++ b/crates/kobold_macros/src/gen/transient.rs
@@ -1,9 +1,9 @@
 use std::fmt::{self, Debug, Display, Write};
-use std::ops::Deref;
 
 use arrayvec::ArrayString;
 use proc_macro::{Literal, TokenStream};
 
+use crate::gen::element::{Attr, InlineAbi};
 use crate::gen::Short;
 use crate::itertools::IteratorExt;
 use crate::tokenize::prelude::*;
@@ -28,7 +28,6 @@ impl Transient {
 
         self.fields.is_empty()
             && self.els.len() == 1
-            && self.js.attr_constructors.len() == 0
             && self.js.functions.len() == 1
             && jsfn.constructor == "Element::new"
             && jsfn.args.is_empty()
@@ -54,18 +53,9 @@ impl Tokenize for Transient {
         }
 
         if self.els.is_empty() {
-            return match self.fields.remove(0) {
-                Field::View { value, .. } | Field::Attribute { value, .. } => {
-                    value.tokenize_in(stream)
-                }
-            };
+            return self.fields.remove(0).value.tokenize_in(stream);
         }
 
-        let abi_lifetime = if self.fields.iter().any(Field::borrows) {
-            "'abi,"
-        } else {
-            ""
-        };
         let js_type = self.js_type.unwrap_or("Node");
 
         let mut generics = String::new();
@@ -103,8 +93,12 @@ impl Tokenize for Transient {
             let args = args
                 .iter()
                 .map(|a| {
-                    let mut temp = ArrayString::<8>::new();
-                    let _ = write!(temp, "{}.js()", a.name);
+                    let mut temp = ArrayString::<24>::new();
+                    let name = a.name;
+                    let _ = match a.abi.map(InlineAbi::method) {
+                        Some(method) => write!(temp, "self.{name}{method}"),
+                        None => write!(temp, "{name}.js()"),
+                    };
                     temp
                 })
                 .join(",");
@@ -144,7 +138,7 @@ impl Tokenize for Transient {
                         {declare}\
                     }}\
                     \
-                    impl<{abi_lifetime}{generics}> ::kobold::View for Transient<{generics}>\
+                    impl<{generics}> ::kobold::View for Transient<{generics}>\
                     where \
                         {bounds}\
                     {{\
@@ -174,7 +168,6 @@ impl Tokenize for Transient {
 
 #[derive(Default)]
 pub struct JsModule {
-    pub attr_constructors: Vec<JsAttrConstructor>,
     pub functions: Vec<JsFunction>,
     pub code: String,
 }
@@ -195,7 +188,7 @@ impl Tokenize for JsModule {
                 ),
             ),
             "extern \"C\"",
-            block((each(self.attr_constructors), each(self.functions))),
+            block(each(self.functions)),
         ))
     }
 }
@@ -240,96 +233,83 @@ impl Tokenize for JsFunction {
 #[derive(Debug)]
 pub struct JsArgument {
     pub name: Short,
-    pub abi: &'static str,
+    pub abi: Option<InlineAbi>,
 }
 
 impl JsArgument {
     pub fn new(name: Short) -> Self {
-        JsArgument {
-            name,
-            abi: "&wasm_bindgen::JsValue",
-        }
+        JsArgument { name, abi: None }
     }
 
-    pub fn with_abi(name: Short, abi: &'static str) -> Self {
-        JsArgument { name, abi }
+    pub fn with_abi(name: Short, abi: InlineAbi) -> Self {
+        JsArgument {
+            name,
+            abi: Some(abi),
+        }
     }
 }
 
 impl Tokenize for JsArgument {
-    fn tokenize(self) -> TokenStream {
-        (ident(&self.name), ':', self.abi, ',').tokenize()
-    }
-
     fn tokenize_in(self, stream: &mut TokenStream) {
-        (ident(&self.name), ':', self.abi, ',').tokenize_in(stream)
+        let abi = self
+            .abi
+            .map(InlineAbi::abi)
+            .unwrap_or("&wasm_bindgen::JsValue");
+
+        (ident(&self.name), ':', abi, ',').tokenize_in(stream)
     }
 }
 
-pub enum Field {
-    View {
-        name: Short,
-        value: TokenStream,
-    },
+pub struct Field {
+    pub name: Short,
+    pub value: TokenStream,
+    pub kind: FieldKind,
+}
+
+pub enum FieldKind {
+    View,
     Attribute {
-        name: Short,
         el: Short,
-        abi: Abi,
-        value: TokenStream,
+        attr: Attr,
+        prop: TokenStream,
     },
-}
-
-pub enum Abi {
-    Owned(&'static str),
-    Borrowed(&'static str),
-}
-
-impl Deref for Abi {
-    type Target = str;
-
-    fn deref(&self) -> &str {
-        match self {
-            Abi::Owned(abi) => abi,
-            Abi::Borrowed(abi) => abi,
-        }
-    }
 }
 
 impl Debug for Field {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Field::View { name, value } => {
+        let Field { name, value, kind } = self;
+
+        match kind {
+            FieldKind::View => {
                 write!(f, "{name} <View>: {value}")
             }
-            Field::Attribute {
-                name,
-                el,
-                abi,
-                value,
-            } => {
-                let abi = abi.deref();
-
-                write!(f, "{name} <Attribute({abi} -> {el})>: {value}")
+            FieldKind::Attribute { attr, .. } => {
+                write!(f, "{name} <AttributeView<{}>>: {value}", attr.name)
             }
         }
     }
 }
 
 impl Field {
-    fn borrows(&self) -> bool {
-        matches!(
-            self,
-            Field::Attribute {
-                abi: Abi::Borrowed(_),
-                ..
-            }
-        )
+    pub fn new(name: Short, value: TokenStream) -> Self {
+        Field {
+            name,
+            value,
+            kind: FieldKind::View,
+        }
+    }
+
+    pub fn attr(&mut self, el: Short, attr: Attr, prop: TokenStream) -> &mut Self {
+        self.kind = FieldKind::Attribute { el, attr, prop };
+        self
+    }
+
+    fn is_view(&self) -> bool {
+        matches!(self.kind, FieldKind::View)
     }
 
     fn name_value(&self) -> (&Short, &TokenStream) {
-        match self {
-            Field::View { name, value } | Field::Attribute { name, value, .. } => (name, value),
-        }
+        (&self.name, &self.value)
     }
 
     fn make_type(&self) -> Short {
@@ -341,20 +321,25 @@ impl Field {
     }
 
     fn bounds(&self, buf: &mut String) {
-        match self {
-            Field::View { name, .. } => {
+        let Field { name, kind, .. } = self;
+
+        match kind {
+            FieldKind::View => {
                 let mut typ = *name;
                 typ.make_ascii_uppercase();
 
                 let _ = write!(buf, "{typ}: ::kobold::View,");
             }
-            Field::Attribute { name, abi, .. } => {
+            FieldKind::Attribute { attr, .. } => {
                 let mut typ = *name;
                 typ.make_ascii_uppercase();
 
-                let abi = abi.deref();
-
-                let _ = write!(buf, "{typ}: ::kobold::attribute::Attribute<Abi = {abi}>,");
+                let _ = write!(
+                    buf,
+                    "{typ}: ::kobold::attribute::AttributeView<::kobold::attribute::{}>{},",
+                    attr.name,
+                    attr.abi.map(InlineAbi::bound).unwrap_or(""),
+                );
             }
         }
     }
@@ -367,34 +352,39 @@ impl Field {
     }
 
     fn build(&self, buf: &mut String) {
-        match self {
-            Field::View { name, .. } => {
-                let _ = write!(buf, "let {name} = self.{name}.build();");
-            }
-            Field::Attribute { name, .. } => {
-                let _ = write!(buf, "let {name} = self.{name};");
-            }
+        let Field { name, .. } = self;
+
+        if self.is_view() {
+            let _ = write!(buf, "let {name} = self.{name}.build();");
         }
     }
 
     fn var(&self, buf: &mut String) {
-        match self {
-            Field::View { name, .. } => {
-                let _ = write!(buf, "{name},");
+        let Field { name, kind, .. } = self;
+
+        let _ = match kind {
+            FieldKind::View => write!(buf, "{name},"),
+            FieldKind::Attribute { attr, .. } if attr.abi.is_some() => {
+                write!(buf, "{name}: self.{name}.build(),")
             }
-            Field::Attribute { name, .. } => {
-                let _ = write!(buf, "{name}: {name}.build(),");
+            FieldKind::Attribute { el, prop, .. } => {
+                write!(buf, "{name}: self.{name}.build_in({prop}, &{el}),")
             }
-        }
+        };
     }
 
     fn update(&self, buf: &mut String) {
-        match self {
-            Field::View { name, .. } => {
+        let Field { name, kind, .. } = self;
+
+        match kind {
+            FieldKind::View => {
                 let _ = write!(buf, "self.{name}.update(&mut p.{name});");
             }
-            Field::Attribute { name, el, .. } => {
-                let _ = write!(buf, "self.{name}.update(&mut p.{name}, &p.{el});");
+            FieldKind::Attribute { el, prop, .. } => {
+                let _ = write!(
+                    buf,
+                    "self.{name}.update_in({prop}, &p.{el}, &mut p.{name});"
+                );
             }
         }
     }

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -3,7 +3,7 @@ use kobold::prelude::*;
 #[component]
 fn Hello(name: &str) -> impl View + '_ {
     view! {
-        <h1>"Hello "{ name }"!"</h1>
+        <h1 test={name} class={name} checked={true}>"Hello "{ name }"!"</h1>
     }
 }
 

--- a/examples/todomvc/index.html
+++ b/examples/todomvc/index.html
@@ -12,7 +12,6 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/todomvc-app-css@2.4.2/index.css"
     />
-
     <link data-trunk rel="rust" />
   </head>
   <body></body>

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -121,7 +121,7 @@ fn EntryView<'a>(idx: usize, entry: &'a Entry, state: &'a Hook<State>) -> impl V
         view! {
             <input .edit
                 type="text"
-                value={entry.description.fast_diff()}
+                value={entry.description.no_diff()}
                 {onmouseover}
                 {onkeypress}
                 {onblur}


### PR DESCRIPTION
This is a major refactor to how Text-coercing values work as both `View` expressions and attributes:

+ All 8-32 bit integers, floats, and bools are passed by their `IntoWasmAbi` value to JS, so they never need to be serialized in Rust, `ryu` is no longer necessary.
+ `u64`, `u128`, `i64`, and `128` are passed as 32 bit integers if the value is in range, otherwise they are serialized in `Rust` using `itoa` as previously. Should relax this a bit to allow integers fitting in `Number.MIN_SAFE_INTEGER ..= Number.MAX_SAFE_INTEGER` range eventually.
+ Element attribute expressions now use their own `AttributeView` trait that allows them to be attached to hoisted (having their own JS function and their own `web_sys::Node` handle in Rust) elements.
+ Provided attributes are now defined as 0-sized structs. All attributes can implement any number of `Property<&str | f64 | bool>` to enforce a type-safe interface for setting their values. Additionally some provided attributes might enforce their types more strictly (like `checked` on `<input>` requires a `bool`).