### PR TITLE
Don't store products of `static` expression `View`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ For more details visit the [`branching` module documentation](https://docs.rs/ko
 
 ### Lists and Iterators
 
-To render an iterator use the [`for`] keyword:
+To render an iterator use the `for` keyword:
 
 ```rust
 // `ListIteratorExt` is included in the prelude
@@ -167,7 +167,7 @@ fn Users<'a>(names: &'a [&'a str]) -> impl View + 'a {
     view! {
         <ul>
         {
-            for names.iter().map(|name| view! { <li>{ name }</li> }).list()
+            for names.iter().map(|name| view! { <li>{ name }</li> })
         }
         </ul>
     }

--- a/crates/kobold_macros/src/dom/expression.rs
+++ b/crates/kobold_macros/src/dom/expression.rs
@@ -13,6 +13,7 @@ use crate::tokenize::prelude::*;
 pub struct Expression {
     pub stream: TokenStream,
     pub span: Span,
+    pub is_static: bool,
 }
 
 impl Debug for Expression {
@@ -36,7 +37,7 @@ impl From<TokenTree> for Expression {
         let span = tt.span();
         let stream = tt.tokenize();
 
-        Expression { stream, span }
+        Expression { stream, span, is_static: false }
     }
 }
 
@@ -73,6 +74,7 @@ impl From<Group> for Expression {
                         (deref.then_some('&'), stream),
                     ),
                     span: group.span(),
+                    is_static,
                 };
             }
         }
@@ -80,6 +82,7 @@ impl From<Group> for Expression {
         Expression {
             stream: stream.collect(),
             span: group.span(),
+            is_static: false,
         }
     }
 }
@@ -89,6 +92,7 @@ impl From<&str> for Expression {
         Expression {
             stream: code.tokenize(),
             span: Span::call_site(),
+            is_static: false,
         }
     }
 }

--- a/crates/kobold_macros/src/dom/expression.rs
+++ b/crates/kobold_macros/src/dom/expression.rs
@@ -37,7 +37,11 @@ impl From<TokenTree> for Expression {
         let span = tt.span();
         let stream = tt.tokenize();
 
-        Expression { stream, span, is_static: false }
+        Expression {
+            stream,
+            span,
+            is_static: false,
+        }
     }
 }
 

--- a/crates/kobold_macros/src/gen.rs
+++ b/crates/kobold_macros/src/gen.rs
@@ -139,7 +139,13 @@ trait IntoGenerator {
 
 impl IntoGenerator for Expression {
     fn into_gen(self, gen: &mut Generator) -> DomNode {
-        DomNode::Variable(gen.add_field(self.stream).name)
+        let field = gen.add_field(self.stream);
+
+        if self.is_static {
+            field.kind = FieldKind::StaticView;
+        }
+
+        DomNode::Variable(field.name)
     }
 }
 

--- a/crates/kobold_macros/src/gen.rs
+++ b/crates/kobold_macros/src/gen.rs
@@ -68,48 +68,6 @@ impl Generator {
         self.out.fields.last_mut().unwrap()
     }
 
-    // fn add_expression(&mut self, value: TokenStream) -> Short {
-    //     let name = self.names.next();
-
-    //     self.out.fields.push(Field::view(name, value));
-
-    //     name
-    // }
-
-    // fn add_attribute(&mut self, el: Short, abi: Abi, value: TokenStream) -> Short {
-    //     let name = self.names.next();
-
-    //     self.out.fields.push(Field {
-    //         name,
-    //         value,
-    //         kind: FieldKind::Attribute { el, abi }
-    //     });
-
-    //     name
-    // }
-
-    // fn attribute_constructor(&mut self, attr: &str) -> JsFnName {
-    //     use std::hash::Hasher;
-
-    //     let mut hasher = fnv::FnvHasher::default();
-    //     attr.hash(&mut hasher);
-
-    //     let hash = hasher.finish();
-    //     let name = JsFnName::try_from(format_args!("__attr_{hash:016x}")).unwrap();
-
-    //     let _ = write!(
-    //         self.out.js.code,
-    //         "export function {name}() {{\
-    //             \nreturn document.createAttribute(\"{attr}\");\
-    //         \n}}\n\
-    //         "
-    //     );
-
-    //     self.out.js.attr_constructors.push(JsAttrConstructor(name));
-
-    //     name
-    // }
-
     fn hoist(&mut self, node: DomNode) -> Option<JsFnName> {
         use std::hash::Hasher;
 

--- a/crates/kobold_macros/src/gen/element.rs
+++ b/crates/kobold_macros/src/gen/element.rs
@@ -154,40 +154,6 @@ impl IntoGenerator for HtmlElement {
                         gen.add_field(expr.stream).attr(var, attr, prop);
                     }
                 },
-                // } else if attr == "checked" {
-                //     el.hoisted = true;
-                //     let value = gen.add_attribute(
-                //         var,
-                //         Abi::Owned("bool"),
-                //         call("::kobold::attribute::Checked", expr.stream),
-                //     );
-
-                //     writeln!(el, "{var}.{attr}={value};");
-
-                //     JsArgument::with_abi(value, "bool")
-                // } else if provided_attr(attr) {
-                //     let value = gen.add_expression(call(
-                //         format_args!("::kobold::attribute::{attr}"),
-                //         expr.stream,
-                //     ));
-
-                //     writeln!(el, "{var}.setAttributeNode({value});");
-
-                //     JsArgument::new(value)
-                // } else {
-                //     let attr_fn = gen.attribute_constructor(attr);
-
-                //     let value = gen.add_expression(call(
-                //         "::kobold::attribute::AttributeNode::new",
-                //         (ident(&attr_fn), ',', expr.stream),
-                //     ));
-
-                //     writeln!(el, "{var}.setAttributeNode({value});");
-
-                //     JsArgument::new(value)
-                // };
-
-                // el.args.push(arg);
             };
         }
 

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -3,7 +3,7 @@ use kobold::prelude::*;
 #[component]
 fn Hello(name: &str) -> impl View + '_ {
     view! {
-        <h1>"Hello "{ name }"!"</h1>
+        <h1>"Hello "{ static name }"!"</h1>
     }
 }
 

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -3,7 +3,7 @@ use kobold::prelude::*;
 #[component]
 fn Hello(name: &str) -> impl View + '_ {
     view! {
-        <h1>"Hello "{ static name }"!"</h1>
+        <h1>"Hello "{ name }"!"</h1>
     }
 }
 

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -90,7 +90,7 @@ fn ToggleAll(active_count: usize, state: &Hook<State>) -> impl View + '_ {
     }
 
     view! {
-        <input #toggle-all.toggle-all type="checkbox" checked={active_count == 0} onclick={onclick} />
+        <input #toggle-all.toggle-all type="checkbox" checked={active_count == 0} {onclick} />
         <label for="toggle-all" />
     }
 }
@@ -161,7 +161,11 @@ fn FilterView(filter: Filter, state: &Hook<State>) -> impl View + '_ {
 
     view! {
         <li>
-            <a {class} {onclick} href={static filter.href()}>{ static filter.label() }</a>
+            <a {class} {onclick} href={static filter.href()}>
+            {
+                static filter.label()
+            }
+            </a>
         </li>
     }
 }


### PR DESCRIPTION
This is just a minor optimization that prevents the `view!` macro from storing the product of static fields that build up a view. Shouldn't have much bearing on performance aside from being ever so slightly more memory efficient.