### PR TITLE
Generic Anchor

### DIFF
--- a/crates/kobold/js/util.js
+++ b/crates/kobold/js/util.js
@@ -31,7 +31,33 @@ export function __kobold_fragment_replace(f,n)
 	f.appendChild(e);
 	f.insertBefore(b, f.firstChild);
 }
+export function __kobold_dyn_unmount(f)
+{
+	let decorators = fragmentDecorators.get(f);
+	if (decorators == null) {
+		f.remove();
+		return;
+	}
 
+	let [b, e] = decorators;
+	while (b.nextSibling !== e) f.appendChild(b.nextSibling);
+	f.appendChild(e);
+	f.insertBefore(b, f.firstChild);
+}
+export function __kobold_dyn_replace(f,n)
+{
+	let decorators = fragmentDecorators.get(f);
+	if (decorators == null) {
+		f.replaceWith(n);
+		return;
+	};
+
+	let [b, e] = decorators;
+	while (b.nextSibling !== e) f.appendChild(b.nextSibling);
+	b.replaceWith(n);
+	f.appendChild(e);
+	f.insertBefore(b, f.firstChild);
+}
 export function __kobold_set_text(n,t) { n.textContent = t; }
 export function __kobold_set_attr(n,a,v) { n.setAttribute(a, v); }
 

--- a/crates/kobold/src/branching.rs
+++ b/crates/kobold/src/branching.rs
@@ -92,7 +92,8 @@
 
 use web_sys::Node;
 
-use crate::{Element, Mountable, View};
+use crate::dom::{self, Anchor, DynAnchor};
+use crate::{Mountable, View};
 
 macro_rules! branch {
     ($name:ident < $($var:ident),* >) => {
@@ -127,7 +128,7 @@ macro_rules! branch {
                     (html, old) => {
                         let new = html.build();
 
-                        old.el().replace_with(new.js());
+                        old.anchor().replace_with(new.js());
 
                         *old = new;
                     }
@@ -142,11 +143,12 @@ macro_rules! branch {
             )*
         {
             type Js = Node;
+            type Anchor = DynAnchor;
 
-            fn el(&self) -> &Element {
+            fn anchor(&self) -> &DynAnchor {
                 match self {
                     $(
-                        $name::$var(p) => p.el(),
+                        $name::$var(p) => p.anchor().as_dyn(),
                     )*
                 }
             }
@@ -164,14 +166,15 @@ branch!(Branch7<A, B, C, D, E, F, G>);
 branch!(Branch8<A, B, C, D, E, F, G, H>);
 branch!(Branch9<A, B, C, D, E, F, G, H, I>);
 
-pub struct EmptyNode(Element);
+pub struct EmptyNode(Node);
 
 pub struct Empty;
 
 impl Mountable for EmptyNode {
     type Js = Node;
+    type Anchor = Node;
 
-    fn el(&self) -> &Element {
+    fn anchor(&self) -> &Node {
         &self.0
     }
 }
@@ -180,7 +183,7 @@ impl View for Empty {
     type Product = EmptyNode;
 
     fn build(self) -> Self::Product {
-        EmptyNode(Element::new_empty())
+        EmptyNode(dom::empty_node())
     }
 
     fn update(self, _: &mut Self::Product) {}
@@ -204,7 +207,7 @@ impl<T: View> View for Option<T> {
             (html, old) => {
                 let new = html.build();
 
-                old.el().replace_with(new.js());
+                old.anchor().replace_with(new.js());
 
                 *old = new;
             }

--- a/crates/kobold/src/diff.rs
+++ b/crates/kobold/src/diff.rs
@@ -9,7 +9,6 @@ use std::ops::Deref;
 use web_sys::Node;
 
 use crate::attribute::AttributeView;
-use crate::dom::Element;
 use crate::value::IntoText;
 use crate::{Mountable, View};
 
@@ -90,9 +89,10 @@ where
     P: Mountable,
 {
     type Js = P::Js;
+    type Anchor = P::Anchor;
 
-    fn el(&self) -> &Element {
-        self.inner.el()
+    fn anchor(&self) -> &Self::Anchor {
+        self.inner.anchor()
     }
 }
 
@@ -240,10 +240,10 @@ macro_rules! impl_no_diff {
         where
             T: IntoText + Copy,
         {
-            type Product = Element;
+            type Product = Node;
 
             fn build(self) -> Self::Product {
-                Element::new(self.into_text())
+                self.into_text()
             }
 
             fn update(self, _: &mut Self::Product) {}

--- a/crates/kobold/src/dom.rs
+++ b/crates/kobold/src/dom.rs
@@ -10,8 +10,81 @@ use wasm_bindgen::JsValue;
 use web_sys::Node;
 
 use crate::util;
-use crate::value::IntoText;
 use crate::Mountable;
+
+pub trait Anchor: AsRef<JsValue> + Clone + 'static {
+    fn replace_with(&self, new: &JsValue);
+
+    fn unmount(&self);
+
+    fn as_dyn(&self) -> &DynAnchor {
+        // Safety: DynAnchor is a #[repr(transparent)] wrapper of
+        // JsValue so this cast is always safe
+        unsafe { &*(self.as_ref() as *const JsValue as *const DynAnchor) }
+    }
+}
+
+pub fn empty_node() -> Node {
+    util::__kobold_empty_node()
+}
+
+impl Anchor for Node {
+    fn replace_with(&self, new: &JsValue) {
+        util::__kobold_replace(self, new)
+    }
+
+    fn unmount(&self) {
+        util::__kobold_unmount(self)
+    }
+}
+
+#[derive(Clone)]
+#[repr(transparent)]
+pub struct Fragment(Node);
+
+impl From<Node> for Fragment {
+    fn from(node: Node) -> Self {
+        util::__kobold_fragment_decorate(&node);
+
+        Fragment(node)
+    }
+}
+
+impl AsRef<JsValue> for Fragment {
+    fn as_ref(&self) -> &JsValue {
+        self.0.as_ref()
+    }
+}
+
+impl Anchor for Fragment {
+    fn replace_with(&self, new: &JsValue) {
+        util::__kobold_fragment_replace(&self.0, new)
+    }
+
+    fn unmount(&self) {
+        util::__kobold_fragment_unmount(&self.0)
+    }
+}
+
+#[derive(Clone)]
+#[repr(transparent)]
+pub struct DynAnchor(JsValue);
+
+impl AsRef<JsValue> for DynAnchor {
+    fn as_ref(&self) -> &JsValue {
+        &self.0
+    }
+}
+
+impl Anchor for DynAnchor {
+    fn replace_with(&self, new: &JsValue) {
+        util::__kobold_dyn_replace(&self.0, new)
+    }
+
+    fn unmount(&self) {
+        util::__kobold_dyn_unmount(&self.0)
+    }
+}
 
 /// A settable property of a DOM `Node`
 pub trait Property<Abi> {
@@ -39,42 +112,16 @@ impl Property<bool> for TextContent {
     }
 }
 
-#[derive(Clone)]
-pub struct Element {
-    kind: Kind,
-    pub(crate) node: Node,
-}
-
-#[derive(Clone, Copy)]
-enum Kind {
-    Element,
-    Fragment,
-}
-
-impl Deref for Element {
-    type Target = Node;
-
-    fn deref(&self) -> &Node {
-        &self.node
-    }
-}
-
-pub struct Fragment {
-    el: Element,
+pub struct FragmentBuilder {
+    fragment: Fragment,
     tail: Node,
 }
 
-impl Fragment {
+impl FragmentBuilder {
     pub fn new() -> Self {
-        let node = util::__kobold_fragment();
-        let tail = util::__kobold_fragment_decorate(&node);
-        Fragment {
-            el: Element {
-                kind: Kind::Fragment,
-                node,
-            },
-            tail,
-        }
+        let fragment = Fragment(util::__kobold_fragment());
+        let tail = util::__kobold_fragment_decorate(&fragment.0);
+        FragmentBuilder { fragment, tail }
     }
 
     pub fn append(&self, child: &JsValue) {
@@ -82,74 +129,28 @@ impl Fragment {
     }
 }
 
-impl Deref for Fragment {
-    type Target = Element;
+impl Deref for FragmentBuilder {
+    type Target = Fragment;
 
-    fn deref(&self) -> &Element {
-        &self.el
+    fn deref(&self) -> &Fragment {
+        &self.fragment
     }
 }
 
-/// A helper trait describing integers that might not fit in the JavaScript
-/// number type and therefore might have to be passed as strings.
-pub trait LargeInt: Sized + Copy + PartialEq + 'static {
-    type Downcast: TryFrom<Self> + Into<f64> + IntoText;
-
-    fn stringify<F: FnOnce(&str) -> R, R>(&self, f: F) -> R;
-}
-
-impl Element {
-    pub fn new(node: Node) -> Self {
-        Element {
-            kind: Kind::Element,
-            node,
-        }
-    }
-
-    pub fn new_text(text: impl IntoText) -> Self {
-        Self::new(text.into_text())
-    }
-
-    pub fn new_empty() -> Self {
-        Self::new(util::__kobold_empty_node())
-    }
-
-    pub fn new_fragment_raw(node: Node) -> Self {
-        util::__kobold_fragment_decorate(&node);
-
-        Element {
-            kind: Kind::Fragment,
-            node,
-        }
-    }
-
-    pub fn anchor(&self) -> &JsValue {
-        &self.node
-    }
-
-    pub fn js(&self) -> &JsValue {
-        &self.node
-    }
-
-    pub fn replace_with(&self, new: &JsValue) {
-        match self.kind {
-            Kind::Element => util::__kobold_replace(&self.node, new),
-            Kind::Fragment => util::__kobold_fragment_replace(&self.node, new),
-        }
-    }
-
-    pub fn unmount(&self) {
-        match self.kind {
-            Kind::Element => util::__kobold_unmount(&self.node),
-            Kind::Fragment => util::__kobold_fragment_unmount(&self.node),
-        }
-    }
-}
-
-impl Mountable for Element {
+impl Mountable for Node {
     type Js = Node;
+    type Anchor = Node;
 
-    fn el(&self) -> &Element {
+    fn anchor(&self) -> &Node {
+        self
+    }
+}
+
+impl Mountable for Fragment {
+    type Js = Node;
+    type Anchor = Fragment;
+
+    fn anchor(&self) -> &Fragment {
         self
     }
 }

--- a/crates/kobold/src/event.rs
+++ b/crates/kobold/src/event.rs
@@ -11,7 +11,8 @@ use wasm_bindgen::closure::Closure;
 use wasm_bindgen::{JsCast, JsValue};
 use web_sys::HtmlElement;
 
-use crate::{Element, Mountable, View};
+use crate::dom::Anchor;
+use crate::{Mountable, View};
 
 /// Smart wrapper around a [`web_sys::Event`](web_sys::Event) which includes type
 /// information for the target element of said event.
@@ -78,7 +79,7 @@ where
 pub struct EventHandler<F>(F);
 
 pub struct ClosureProduct<F> {
-    js: JsValue,
+    js: JsClosure,
     boxed: Box<F>,
 }
 
@@ -95,7 +96,10 @@ where
         // `into_js_value` will _forget_ the previous Box, so we can safely reconstruct it
         let boxed = unsafe { Box::from_raw(raw) };
 
-        ClosureProduct { js, boxed }
+        ClosureProduct {
+            js: JsClosure(js),
+            boxed,
+        }
     }
 
     fn update(&mut self, f: F) {
@@ -118,17 +122,36 @@ where
     }
 }
 
+#[derive(Clone)]
+#[repr(transparent)]
+pub struct JsClosure(JsValue);
+
+impl AsRef<JsValue> for JsClosure {
+    fn as_ref(&self) -> &JsValue {
+        &self.0
+    }
+}
+
+impl Anchor for JsClosure {
+    fn replace_with(&self, _: &JsValue) {
+        debug_assert!(false, "Using JsClosure as a DOM Node");
+    }
+
+    fn unmount(&self) {}
+}
+
 impl<F> Mountable for ClosureProduct<F>
 where
     F: 'static,
 {
     type Js = JsValue;
+    type Anchor = JsClosure;
 
-    fn el(&self) -> &Element {
-        panic!("Closure is not an element");
+    fn anchor(&self) -> &JsClosure {
+        &self.js
     }
 
     fn js(&self) -> &JsValue {
-        &self.js
+        &self.js.0
     }
 }

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -316,7 +316,7 @@ pub mod prelude {
     pub use crate::stateful::{stateful, Hook, IntoState, Signal, Then};
 }
 
-use dom::Element;
+use dom::Anchor;
 
 /// Crate re-exports for the [`view!`](view) macro internals
 pub mod reexport {
@@ -377,7 +377,7 @@ where
     fn build(self) -> Self::Product {
         let prod = self.html.build();
 
-        (self.handler)(prod.el().unchecked_ref());
+        (self.handler)(prod.js().unchecked_ref());
 
         prod
     }
@@ -402,7 +402,7 @@ where
     fn build(self) -> Self::Product {
         let prod = self.html.build();
 
-        (self.handler)(prod.el().unchecked_ref());
+        (self.handler)(prod.js().unchecked_ref());
 
         prod
     }
@@ -410,18 +410,19 @@ where
     fn update(self, p: &mut Self::Product) {
         self.html.update(p);
 
-        (self.handler)(p.el().unchecked_ref());
+        (self.handler)(p.js().unchecked_ref());
     }
 }
 
 /// A type that can be mounted in the DOM
 pub trait Mountable: 'static {
     type Js: JsCast;
+    type Anchor: Anchor;
 
-    fn el(&self) -> &Element;
+    fn anchor(&self) -> &Self::Anchor;
 
     fn js(&self) -> &JsValue {
-        self.el().anchor()
+        self.anchor().as_ref()
     }
 }
 

--- a/crates/kobold/src/list.rs
+++ b/crates/kobold/src/list.rs
@@ -6,8 +6,8 @@
 
 use web_sys::Node;
 
-use crate::dom::Fragment;
-use crate::{Element, Mountable, View};
+use crate::dom::{Anchor, Fragment, FragmentBuilder};
+use crate::{Mountable, View};
 
 /// Wrapper type that implements `View` for iterators. Use the [`list`](ListIteratorExt::list)
 /// method on the iterator to create one.
@@ -17,13 +17,14 @@ pub struct List<T>(pub(crate) T);
 pub struct ListProduct<T> {
     list: Vec<T>,
     visible: usize,
-    fragment: Fragment,
+    fragment: FragmentBuilder,
 }
 
 impl<T: 'static> Mountable for ListProduct<T> {
     type Js = Node;
+    type Anchor = Fragment;
 
-    fn el(&self) -> &Element {
+    fn anchor(&self) -> &Fragment {
         &self.fragment
     }
 }
@@ -49,7 +50,7 @@ where
 
     fn build(self) -> Self::Product {
         let iter = self.0.into_iter();
-        let fragment = Fragment::new();
+        let fragment = FragmentBuilder::new();
 
         let list: Vec<_> = iter
             .map(|item| {
@@ -81,7 +82,7 @@ where
 
         if p.visible > updated {
             for old in p.list[updated..p.visible].iter() {
-                old.el().unmount();
+                old.anchor().unmount();
             }
             p.visible = updated;
         } else {

--- a/crates/kobold/src/util.rs
+++ b/crates/kobold/src/util.rs
@@ -5,7 +5,6 @@
 use wasm_bindgen::prelude::*;
 use web_sys::Node;
 
-use crate::dom::Element;
 use crate::View;
 
 /// Wrapper that turns `extern` precompiled JavaScript functions into [`View`](View)s.
@@ -16,13 +15,13 @@ impl<F> View for Precompiled<F>
 where
     F: Fn() -> Node,
 {
-    type Product = Element;
+    type Product = Node;
 
-    fn build(self) -> Element {
-        Element::new(self.0())
+    fn build(self) -> Node {
+        self.0()
     }
 
-    fn update(self, _: &mut Element) {}
+    fn update(self, _: &mut Node) {}
 }
 
 #[wasm_bindgen]
@@ -50,6 +49,8 @@ extern "C" {
     pub(crate) fn __kobold_fragment_append(f: &Node, c: &JsValue);
     pub(crate) fn __kobold_fragment_unmount(f: &Node);
     pub(crate) fn __kobold_fragment_replace(f: &Node, new: &JsValue);
+    pub(crate) fn __kobold_dyn_unmount(f: &JsValue);
+    pub(crate) fn __kobold_dyn_replace(f: &JsValue, new: &JsValue);
 
     // `set_text` variants ----------------
 

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -83,6 +83,24 @@ fn EntryInput(state: &Hook<State>) -> impl View + '_ {
     }
 }
 
+mod test {
+    use super::*;
+
+
+    #[component]
+    fn ToggleAll(active_count: usize, state: &Hook<State>) -> impl View + '_ {
+        bind! { state:
+            let onclick = move |_| state.set_all(active_count != 0);
+        }
+
+        view! {
+            <input #toggle-all.toggle-all type="checkbox" checked={active_count == 0} {onclick} />
+            <label for="toggle-all" />
+        }
+    }
+
+}
+
 #[component]
 fn ToggleAll(active_count: usize, state: &Hook<State>) -> impl View + '_ {
     bind! { state:


### PR DESCRIPTION
This replaces the `dom::Element` type with a generic trait `Anchor` implemented for types:

1. `Node`: regular DOM node
2. `dom::Fragment`: transparent wrapper around `Node` referencing a document fragment.
3. `dom::DynAnchor`: transparent wrapper around `JsValue` that may or may not be referencing a document fragment.