### PR TITLE
Remove DynAnchor

### DIFF
--- a/crates/kobold/js/util.js
+++ b/crates/kobold/js/util.js
@@ -31,33 +31,6 @@ export function __kobold_fragment_replace(f,n)
 	f.appendChild(e);
 	f.insertBefore(b, f.firstChild);
 }
-export function __kobold_dyn_unmount(f)
-{
-	let decorators = fragmentDecorators.get(f);
-	if (decorators == null) {
-		f.remove();
-		return;
-	}
-
-	let [b, e] = decorators;
-	while (b.nextSibling !== e) f.appendChild(b.nextSibling);
-	f.appendChild(e);
-	f.insertBefore(b, f.firstChild);
-}
-export function __kobold_dyn_replace(f,n)
-{
-	let decorators = fragmentDecorators.get(f);
-	if (decorators == null) {
-		f.replaceWith(n);
-		return;
-	};
-
-	let [b, e] = decorators;
-	while (b.nextSibling !== e) f.appendChild(b.nextSibling);
-	b.replaceWith(n);
-	f.appendChild(e);
-	f.insertBefore(b, f.firstChild);
-}
 export function __kobold_set_text(n,t) { n.textContent = t; }
 export function __kobold_set_attr(n,a,v) { n.setAttribute(a, v); }
 

--- a/crates/kobold/src/branching.rs
+++ b/crates/kobold/src/branching.rs
@@ -93,7 +93,7 @@
 use wasm_bindgen::JsValue;
 use web_sys::Node;
 
-use crate::dom::{self, Anchor, DynAnchor};
+use crate::dom::{self, Anchor};
 use crate::{Mountable, View};
 
 macro_rules! branch {
@@ -129,7 +129,7 @@ macro_rules! branch {
                     (html, old) => {
                         let new = html.build();
 
-                        old.anchor().replace_with(new.js());
+                        old.replace_with(new.js());
 
                         *old = new;
                     }
@@ -144,12 +144,11 @@ macro_rules! branch {
             )*
         {
             type Js = Node;
-            type Anchor = DynAnchor;
 
-            fn anchor(&self) -> &DynAnchor {
+            fn js(&self) -> &JsValue {
                 match self {
                     $(
-                        $name::$var(p) => p.anchor().as_dyn(),
+                        $name::$var(p) => p.js(),
                     )*
                 }
             }
@@ -187,7 +186,7 @@ pub struct EmptyNode(Node);
 
 pub struct Empty;
 
-impl Mountable for EmptyNode {
+impl Anchor for EmptyNode {
     type Js = Node;
     type Anchor = Node;
 

--- a/crates/kobold/src/diff.rs
+++ b/crates/kobold/src/diff.rs
@@ -9,7 +9,7 @@ use std::ops::Deref;
 use web_sys::Node;
 
 use crate::attribute::AttributeView;
-use crate::dom::TextContent;
+use crate::dom::{Anchor, TextContent};
 use crate::value::{IntoText, Value};
 use crate::{Mountable, View};
 
@@ -84,16 +84,15 @@ where
     }
 }
 
-impl<D, P> Mountable for Fence<D, P>
+impl<D, P> Anchor for Fence<D, P>
 where
-    D: 'static,
     P: Mountable,
 {
     type Js = P::Js;
-    type Anchor = P::Anchor;
+    type Anchor = P;
 
-    fn anchor(&self) -> &Self::Anchor {
-        self.inner.anchor()
+    fn anchor(&self) -> &P {
+        &self.inner
     }
 }
 

--- a/crates/kobold/src/event.rs
+++ b/crates/kobold/src/event.rs
@@ -11,7 +11,6 @@ use wasm_bindgen::closure::Closure;
 use wasm_bindgen::{JsCast, JsValue};
 use web_sys::HtmlElement;
 
-use crate::dom::Anchor;
 use crate::{Mountable, View};
 
 /// Smart wrapper around a [`web_sys::Event`](web_sys::Event) which includes type
@@ -79,7 +78,7 @@ where
 pub struct EventHandler<F>(F);
 
 pub struct ClosureProduct<F> {
-    js: JsClosure,
+    js: JsValue,
     boxed: Box<F>,
 }
 
@@ -96,10 +95,7 @@ where
         // `into_js_value` will _forget_ the previous Box, so we can safely reconstruct it
         let boxed = unsafe { Box::from_raw(raw) };
 
-        ClosureProduct {
-            js: JsClosure(js),
-            boxed,
-        }
+        ClosureProduct { js, boxed }
     }
 
     fn update(&mut self, f: F) {
@@ -122,36 +118,19 @@ where
     }
 }
 
-#[derive(Clone)]
-#[repr(transparent)]
-pub struct JsClosure(JsValue);
-
-impl AsRef<JsValue> for JsClosure {
-    fn as_ref(&self) -> &JsValue {
-        &self.0
-    }
-}
-
-impl Anchor for JsClosure {
-    fn replace_with(&self, _: &JsValue) {
-        debug_assert!(false, "Using JsClosure as a DOM Node");
-    }
-
-    fn unmount(&self) {}
-}
-
 impl<F> Mountable for ClosureProduct<F>
 where
     F: 'static,
 {
     type Js = JsValue;
-    type Anchor = JsClosure;
 
-    fn anchor(&self) -> &JsClosure {
+    fn js(&self) -> &JsValue {
         &self.js
     }
 
-    fn js(&self) -> &JsValue {
-        &self.js.0
+    fn unmount(&self) {}
+
+    fn replace_with(&self, _: &JsValue) {
+        debug_assert!(false, "Using JsClosure as a DOM Node");
     }
 }

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -417,12 +417,23 @@ where
 /// A type that can be mounted in the DOM
 pub trait Mountable: 'static {
     type Js: JsCast;
-    type Anchor: Anchor;
 
-    fn anchor(&self) -> &Self::Anchor;
+    fn js(&self) -> &JsValue;
+
+    fn unmount(&self);
+
+    fn replace_with(&self, new: &JsValue);
+}
+
+impl<T> Mountable for T
+where
+    T: Anchor + 'static,
+    T::Anchor: Mountable,
+{
+    type Js = T::Js;
 
     fn js(&self) -> &JsValue {
-        self.anchor().as_ref()
+        self.anchor().js()
     }
 
     fn unmount(&self) {

--- a/crates/kobold/src/list.rs
+++ b/crates/kobold/src/list.rs
@@ -6,7 +6,7 @@
 
 use web_sys::Node;
 
-use crate::dom::{Fragment, FragmentBuilder};
+use crate::dom::{Anchor, Fragment, FragmentBuilder};
 use crate::{Mountable, View};
 
 /// Wrapper type that implements `View` for iterators. Use the [`list`](ListIteratorExt::list)
@@ -20,7 +20,7 @@ pub struct ListProduct<T> {
     fragment: FragmentBuilder,
 }
 
-impl<T: 'static> Mountable for ListProduct<T> {
+impl<T> Anchor for ListProduct<T> {
     type Js = Node;
     type Anchor = Fragment;
 

--- a/crates/kobold/src/stateful.rs
+++ b/crates/kobold/src/stateful.rs
@@ -12,13 +12,15 @@
 //! be used to create views that have ownership over some arbitrary mutable state.
 //!
 use std::cell::{Cell, UnsafeCell};
-use std::mem::{ManuallyDrop, MaybeUninit};
+use std::marker::PhantomData;
+use std::mem::ManuallyDrop;
 use std::rc::{Rc, Weak};
 
+use wasm_bindgen::JsValue;
 use web_sys::Node;
 
 use crate::diff::Diff;
-use crate::dom::Anchor;
+use crate::dom::DynAnchor;
 use crate::{Mountable, View};
 
 mod hook;
@@ -29,12 +31,51 @@ pub use should_render::{ShouldRender, Then};
 
 pub struct Inner<S> {
     hook: Hook<S>,
-    updater: Box<dyn FnMut(&Hook<S>)>,
+    prod: Box<dyn Product<S>>,
+}
+
+trait Product<S> {
+    fn update(&mut self, hook: &Hook<S>);
+
+    fn js(&self) -> &JsValue;
+
+    fn unmount(&self);
+
+    fn replace_with(&self, new: &JsValue);
+}
+
+struct ProductHandler<S, P, F> {
+    updater: F,
+    product: P,
+    _state: PhantomData<S>,
+}
+
+impl<S, P, F> Product<S> for ProductHandler<S, P, F>
+where
+    S: 'static,
+    P: Mountable,
+    F: FnMut(*const Hook<S>, *mut P),
+{
+    fn update(&mut self, hook: &Hook<S>) {
+        (self.updater)(hook, &mut self.product);
+    }
+
+    fn js(&self) -> &JsValue {
+        self.product.js()
+    }
+
+    fn unmount(&self) {
+        self.product.unmount()
+    }
+
+    fn replace_with(&self, new: &JsValue) {
+        self.product.replace_with(new)
+    }
 }
 
 impl<S> Inner<S> {
     fn update(&mut self) {
-        (self.updater)(&self.hook)
+        self.prod.update(&self.hook)
     }
 }
 
@@ -68,9 +109,8 @@ pub struct Stateful<S, F> {
     render: F,
 }
 
-pub struct StatefulProduct<S, A> {
+pub struct StatefulProduct<S> {
     inner: Rc<WithCell<Inner<S>>>,
-    anchor: A,
 }
 
 /// Create a stateful [`View`](crate::View) over some mutable state. The state
@@ -128,34 +168,30 @@ where
     F: Fn(*const Hook<S::State>) -> V + 'static,
     V: View,
 {
-    type Product = StatefulProduct<S::State, <V::Product as Mountable>::Anchor>;
+    type Product = StatefulProduct<S::State>;
 
     fn build(self) -> Self::Product {
-        let mut el = MaybeUninit::uninit();
-        let el_ref = &mut el;
-
         let inner = Rc::new_cyclic(move |weak| {
             let hook = Hook {
                 state: self.state.init(),
                 inner: WeakRef(weak.as_ptr()),
             };
 
-            let mut product = (self.render)(&hook).build();
-
-            el_ref.write(product.anchor().clone());
+            let product = (self.render)(&hook).build();
 
             WithCell::new(Inner {
                 hook,
-                updater: Box::new(move |hook| {
-                    (self.render)(hook).update(&mut product);
+                prod: Box::new(ProductHandler {
+                    updater: move |hook, product: *mut V::Product| {
+                        (self.render)(hook).update(unsafe { &mut *product })
+                    },
+                    product,
+                    _state: PhantomData,
                 }),
             })
         });
 
-        StatefulProduct {
-            inner,
-            anchor: unsafe { el.assume_init() },
-        }
+        StatefulProduct { inner }
     }
 
     fn update(self, p: &mut Self::Product) {
@@ -167,16 +203,27 @@ where
     }
 }
 
-impl<S, A> Mountable for StatefulProduct<S, A>
+impl<S> Mountable for StatefulProduct<S>
 where
     S: 'static,
-    A: Anchor,
 {
     type Js = Node;
-    type Anchor = A;
+    type Anchor = DynAnchor;
 
-    fn anchor(&self) -> &A {
-        &self.anchor
+    fn js(&self) -> &JsValue {
+        unsafe { self.inner.borrow_unchecked().prod.js() }
+    }
+
+    fn unmount(&self) {
+        unsafe { self.inner.borrow_unchecked().prod.unmount() }
+    }
+
+    fn replace_with(&self, new: &JsValue) {
+        unsafe { self.inner.borrow_unchecked().prod.replace_with(new) }
+    }
+
+    fn anchor(&self) -> &DynAnchor {
+        panic!()
     }
 }
 
@@ -200,14 +247,13 @@ pub struct Once<S, R, F> {
     handler: F,
 }
 
-impl<S, R, F, A> View for Once<S, R, F>
+impl<S, R, F> View for Once<S, R, F>
 where
     S: IntoState,
     F: FnOnce(Signal<S::State>),
-    A: Anchor,
-    Stateful<S, R>: View<Product = StatefulProduct<S::State, A>>,
+    Stateful<S, R>: View<Product = StatefulProduct<S::State>>,
 {
-    type Product = StatefulProduct<S::State, A>;
+    type Product = StatefulProduct<S::State>;
 
     fn build(self) -> Self::Product {
         let product = self.with_state.build();
@@ -232,7 +278,7 @@ struct WithCell<T> {
 }
 
 impl<T> WithCell<T> {
-    pub fn new(data: T) -> Self {
+    pub const fn new(data: T) -> Self {
         WithCell {
             borrowed: Cell::new(false),
             data: UnsafeCell::new(data),
@@ -250,6 +296,10 @@ impl<T> WithCell<T> {
         self.borrowed.set(true);
         mutator(unsafe { &mut *self.data.get() });
         self.borrowed.set(false);
+    }
+
+    pub unsafe fn borrow_unchecked(&self) -> &T {
+        &*self.data.get()
     }
 }
 

--- a/crates/kobold/src/stateful.rs
+++ b/crates/kobold/src/stateful.rs
@@ -20,7 +20,6 @@ use wasm_bindgen::JsValue;
 use web_sys::Node;
 
 use crate::diff::Diff;
-use crate::dom::DynAnchor;
 use crate::{Mountable, View};
 
 mod hook;
@@ -208,7 +207,6 @@ where
     S: 'static,
 {
     type Js = Node;
-    type Anchor = DynAnchor;
 
     fn js(&self) -> &JsValue {
         unsafe { self.inner.borrow_unchecked().prod.js() }
@@ -220,10 +218,6 @@ where
 
     fn replace_with(&self, new: &JsValue) {
         unsafe { self.inner.borrow_unchecked().prod.replace_with(new) }
-    }
-
-    fn anchor(&self) -> &DynAnchor {
-        panic!()
     }
 }
 

--- a/crates/kobold/src/util.rs
+++ b/crates/kobold/src/util.rs
@@ -49,8 +49,6 @@ extern "C" {
     pub(crate) fn __kobold_fragment_append(f: &Node, c: &JsValue);
     pub(crate) fn __kobold_fragment_unmount(f: &Node);
     pub(crate) fn __kobold_fragment_replace(f: &Node, new: &JsValue);
-    pub(crate) fn __kobold_dyn_unmount(f: &JsValue);
-    pub(crate) fn __kobold_dyn_replace(f: &JsValue, new: &JsValue);
 
     // `set_text` variants ----------------
 

--- a/crates/kobold/src/value.rs
+++ b/crates/kobold/src/value.rs
@@ -5,10 +5,10 @@
 use web_sys::Node;
 
 use crate::diff::{Diff, Ref};
-use crate::dom::{Property, TextContent};
+use crate::dom::{Anchor, Property, TextContent};
 use crate::util;
 
-use crate::{Mountable, View};
+use crate::View;
 
 /// Value that can be set as a property on DOM node
 pub trait Value<P> {
@@ -73,8 +73,8 @@ pub struct TextProduct<M> {
     node: Node,
 }
 
-impl<M: 'static> Mountable for TextProduct<M> {
-    type Js = web_sys::Text;
+impl<M> Anchor for TextProduct<M> {
+    type Js = Node;
     type Anchor = Node;
 
     fn anchor(&self) -> &Node {

--- a/crates/kobold/src/value.rs
+++ b/crates/kobold/src/value.rs
@@ -7,7 +7,6 @@ use web_sys::Node;
 use crate::diff::{Diff, Ref};
 use crate::dom::{Anchor, Property, TextContent};
 use crate::util;
-
 use crate::View;
 
 /// Value that can be set as a property on DOM node
@@ -74,7 +73,7 @@ pub struct TextProduct<M> {
 }
 
 impl<M> Anchor for TextProduct<M> {
-    type Js = Node;
+    type Js = web_sys::Text;
     type Anchor = Node;
 
     fn anchor(&self) -> &Node {

--- a/crates/kobold_macros/src/gen/transient.rs
+++ b/crates/kobold_macros/src/gen/transient.rs
@@ -140,7 +140,7 @@ impl Tokenize for Transient {
                         {declare_els}\
                     }}\
                     \
-                    impl<{product_generics}> ::kobold::Mountable for TransientProduct<{product_generics}>\
+                    impl<{product_generics}> ::kobold::dom::Anchor for TransientProduct<{product_generics}>\
                     where \
                         Self: 'static,\
                     {{\


### PR DESCRIPTION
Seemed like a footgun, needed to do an extra trait for a trait object in stateful, but that also looks safer now.