### PR TITLE
Span generic bounds for expression attributes

### DIFF
--- a/crates/kobold/src/attribute.rs
+++ b/crates/kobold/src/attribute.rs
@@ -144,7 +144,7 @@ macro_rules! impl_attribute_view {
     };
 }
 
-impl_attribute_view!(&str, &String, Ref<'_, str>);
+impl_attribute_view!(&str, &String, &Ref<str>);
 impl_attribute_view!(u8, u16, u32, u64, u128, usize, isize, i8, i16, i32, i64, i128, f32, f64);
 
 #[inline]

--- a/crates/kobold/src/diff.rs
+++ b/crates/kobold/src/diff.rs
@@ -167,39 +167,31 @@ impl_diff!(bool, u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize,
 /// Smart [`View`](View) that only updates its content when the reference to T has changed.
 /// See [`ref`](crate::keywords::ref).
 #[repr(transparent)]
-pub struct Ref<'a, T: ?Sized>(pub(crate) &'a T);
+pub struct Ref<T: ?Sized>(T);
 
-impl<T: ?Sized> Clone for Ref<'_, T> {
-    fn clone(&self) -> Self {
-        Ref(self.0)
-    }
-}
-
-impl<T: ?Sized> Copy for Ref<'_, T> {}
-
-impl<T: ?Sized> Deref for Ref<'_, T> {
+impl<T: ?Sized> Deref for Ref<T> {
     type Target = T;
 
     fn deref(&self) -> &T {
-        self.0
+        &self.0
     }
 }
 
-impl<T: ?Sized> AsRef<T> for Ref<'_, T> {
+impl<T: ?Sized> AsRef<T> for Ref<T> {
     fn as_ref(&self) -> &T {
-        self.0
+        &self.0
     }
 }
 
-impl<T: ?Sized> Diff for Ref<'_, T> {
+impl<T: ?Sized> Diff for &Ref<T> {
     type Memo = *const ();
 
     fn into_memo(self) -> Self::Memo {
-        self.0 as *const _ as *const ()
+        &self.0 as *const _ as *const ()
     }
 
     fn diff(self, memo: &mut Self::Memo) -> bool {
-        let ptr = self.0 as *const _ as *const ();
+        let ptr = &self.0 as *const _ as *const ();
 
         if ptr != *memo {
             *memo = ptr;
@@ -299,12 +291,12 @@ impl_no_diff!(Static, false);
 #[doc(hidden)]
 pub trait StrExt {
     #[deprecated(since = "0.6.0", note = "please use `{ ref <expression> }` instead")]
-    fn fast_diff(&self) -> Ref<str>;
+    fn fast_diff(&self) -> &Ref<str>;
 }
 
 #[doc(hidden)]
 impl StrExt for str {
-    fn fast_diff(&self) -> Ref<str> {
-        Ref(self)
+    fn fast_diff(&self) -> &Ref<str> {
+        crate::keywords::r#ref(self)
     }
 }

--- a/crates/kobold/src/keywords.rs
+++ b/crates/kobold/src/keywords.rs
@@ -54,8 +54,8 @@ where
 ///     }
 /// }
 /// ```
-pub const fn r#ref(value: &str) -> Ref<str> {
-    Ref(value)
+pub const fn r#ref(value: &str) -> &Ref<str> {
+    unsafe { &*(value as *const _ as *const Ref<str>) }
 }
 
 /// `{ use ... }`: disable diffing for `T` and apply its value to the DOM on every render.

--- a/crates/kobold/src/value.rs
+++ b/crates/kobold/src/value.rs
@@ -54,18 +54,9 @@ macro_rules! impl_value {
     };
 }
 
-impl_value!(&'a str: &str, &String);
+impl_value!(&'a str: &str, &String, &Ref<str>);
 impl_value!(bool: bool);
 impl_value!(f64: u8, u16, u32, usize, i8, i16, i32, isize, f32, f64);
-
-impl<P> Value<P> for Ref<'_, str>
-where
-    P: for<'a> Property<&'a str>,
-{
-    fn set_prop(self, prop: P, node: &Node) {
-        prop.set(node, &self);
-    }
-}
 
 pub struct TextProduct<M> {
     memo: M,
@@ -168,7 +159,7 @@ macro_rules! impl_text_view {
     };
 }
 
-impl_text_view!(&str, &String, Ref<'_, str>);
+impl_text_view!(&str, &String, &Ref<str>);
 impl_text_view!(bool, u8, u16, u32, u64, u128, usize, isize, i8, i16, i32, i64, i128, f32, f64);
 
 impl<'a> View for &&'a str {

--- a/crates/kobold_macros/src/dom.rs
+++ b/crates/kobold_macros/src/dom.rs
@@ -53,7 +53,7 @@ pub struct Component {
 pub struct HtmlElement {
     pub name: String,
     pub span: Span,
-    pub classes: Vec<CssValue>,
+    pub classes: Vec<(Span, CssValue)>,
     pub attributes: Vec<Attribute>,
     pub children: Option<Vec<Node>>,
 }
@@ -165,8 +165,8 @@ impl Node {
                 let mut attributes = Vec::new();
 
                 loop {
-                    if content.allow_consume('.').is_some() {
-                        classes.push(content.parse()?);
+                    if let Some(dot) = content.allow_consume('.') {
+                        classes.push((dot.span(), content.parse()?));
                     } else if let Some(hash) = content.allow_consume('#') {
                         let name = Ident::new("id", hash.span());
                         let value: CssValue = content.parse()?;
@@ -184,7 +184,7 @@ impl Node {
                     let attr: Attribute = content.parse()?;
 
                     if attr.name.eq_str("class") {
-                        classes.push(CssValue::try_from(attr.value)?);
+                        classes.push((attr.name.span(), CssValue::try_from(attr.value)?));
                     } else {
                         attributes.push(attr);
                     }

--- a/crates/kobold_macros/src/gen/element.rs
+++ b/crates/kobold_macros/src/gen/element.rs
@@ -140,7 +140,10 @@ impl IntoGenerator for HtmlElement {
                     AttributeType::Provided(attr) => {
                         el.hoisted = true;
 
-                        let value = gen.add_field(expr.stream).attr(var, span, attr, attr.prop()).name;
+                        let value = gen
+                            .add_field(expr.stream)
+                            .attr(var, span, attr, attr.prop())
+                            .name;
 
                         if let Some(abi) = attr.abi {
                             writeln!(el, "{var}.{name}={value};");

--- a/crates/kobold_macros/src/gen/transient.rs
+++ b/crates/kobold_macros/src/gen/transient.rs
@@ -5,7 +5,7 @@
 use std::fmt::{self, Debug, Display, Write};
 
 use arrayvec::ArrayString;
-use proc_macro::{Literal, TokenStream};
+use proc_macro::{Literal, Span, TokenStream};
 
 use crate::gen::element::{Attr, InlineAbi};
 use crate::gen::Short;
@@ -305,6 +305,7 @@ pub enum FieldKind {
     Attribute {
         el: Short,
         attr: Attr,
+        span: Span,
         prop: TokenStream,
     },
 }
@@ -336,8 +337,13 @@ impl Field {
         }
     }
 
-    pub fn attr(&mut self, el: Short, attr: Attr, prop: TokenStream) -> &mut Self {
-        self.kind = FieldKind::Attribute { el, attr, prop };
+    pub fn attr(&mut self, el: Short, span: Span, attr: Attr, prop: TokenStream) -> &mut Self {
+        self.kind = FieldKind::Attribute {
+            el,
+            span,
+            attr,
+            prop,
+        };
         self
     }
 

--- a/crates/kobold_macros/src/gen/transient.rs
+++ b/crates/kobold_macros/src/gen/transient.rs
@@ -408,7 +408,7 @@ impl Field {
                     ": ::kobold::attribute::AttributeView<::kobold::attribute::",
                     Ident::new(attr.name, *span),
                     '>',
-                    attr.abi.map(InlineAbi::bound).unwrap_or(""),
+                    attr.abi.map(InlineAbi::bound),
                     ',',
                 ));
             }

--- a/crates/kobold_macros/src/gen/transient.rs
+++ b/crates/kobold_macros/src/gen/transient.rs
@@ -5,7 +5,7 @@
 use std::fmt::{self, Debug, Display, Write};
 
 use arrayvec::ArrayString;
-use proc_macro::{Literal, Span, TokenStream};
+use proc_macro::{Ident, Literal, Span, TokenStream};
 
 use crate::gen::element::{Attr, InlineAbi};
 use crate::gen::Short;
@@ -47,6 +47,30 @@ impl Transient {
         ))
         .tokenize_in(stream)
     }
+
+    fn tokenize_impl_view_sig(&self) -> TokenStream {
+        let mut generics = String::new();
+
+        for field in self.fields.iter() {
+            let typ = field.make_type();
+
+            let _ = write!(generics, "{typ},");
+        }
+
+        let mut impl_view_sig = format_args!(
+            "\
+            impl<{generics}> ::kobold::View for Transient<{generics}>\
+            where \
+            "
+        )
+        .tokenize();
+
+        for field in self.fields.iter() {
+            field.bounds(&mut impl_view_sig);
+        }
+
+        impl_view_sig
+    }
 }
 
 impl Tokenize for Transient {
@@ -56,6 +80,8 @@ impl Tokenize for Transient {
             return;
         }
 
+        let impl_view_sig = self.tokenize_impl_view_sig();
+
         if self.els.is_empty() {
             return self.fields.remove(0).value.tokenize_in(stream);
         }
@@ -64,7 +90,6 @@ impl Tokenize for Transient {
 
         let mut generics = String::new();
 
-        let mut bounds = String::new();
         let mut build = String::new();
         let mut update = String::new();
         let mut declare = String::new();
@@ -79,7 +104,6 @@ impl Tokenize for Transient {
 
             let _ = write!(generics, "{typ},");
 
-            field.bounds(&mut bounds);
             field.build(&mut build);
             field.update(&mut update);
             field.declare(&mut declare);
@@ -135,48 +159,49 @@ impl Tokenize for Transient {
             self.js,
             format_args!(
                 "\
-                    struct TransientProduct <{product_generics}> {{\
-                        {product_declare}\
-                        {declare_els}\
-                    }}\
+                struct TransientProduct <{product_generics}> {{\
+                    {product_declare}\
+                    {declare_els}\
+                }}\
+                \
+                impl<{product_generics}> ::kobold::dom::Anchor for TransientProduct<{product_generics}>\
+                where \
+                    Self: 'static,\
+                {{\
+                    type Js = ::kobold::reexport::web_sys::{js_type};\
+                    type Anchor = {anchor_type};\
                     \
-                    impl<{product_generics}> ::kobold::dom::Anchor for TransientProduct<{product_generics}>\
-                    where \
-                        Self: 'static,\
-                    {{\
-                        type Js = ::kobold::reexport::web_sys::{js_type};\
-                        type Anchor = {anchor_type};\
+                    fn anchor(&self) -> &Self::Anchor {{\
+                        &self.e0\
+                    }}\
+                }}\
+                \
+                struct Transient <{generics}> {{\
+                    {declare}\
+                }}\
+                "
+            ),
+            impl_view_sig,
+            format_args!(
+                "\
+                {{\
+                    type Product = TransientProduct<{product_generics_binds}>;\
+                    \
+                    fn build(self) -> Self::Product {{\
+                        {build}\
                         \
-                        fn anchor(&self) -> &Self::Anchor {{\
-                            &self.e0\
+                        TransientProduct {{\
+                            {vars}\
                         }}\
                     }}\
                     \
-                    struct Transient <{generics}> {{\
-                        {declare}\
+                    fn update(self, p: &mut Self::Product) {{\
+                        {update}\
                     }}\
-                    \
-                    impl<{generics}> ::kobold::View for Transient<{generics}>\
-                    where \
-                        {bounds}\
-                    {{\
-                        type Product = TransientProduct<{product_generics_binds}>;\
-                        \
-                        fn build(self) -> Self::Product {{\
-                            {build}\
-                            \
-                            TransientProduct {{\
-                                {vars}\
-                            }}\
-                        }}\
-                        \
-                        fn update(self, p: &mut Self::Product) {{\
-                            {update}\
-                        }}\
-                    }}\
-                    \
-                    Transient\
-                    "
+                }}\
+                \
+                Transient\
+                "
             ),
             block(each(self.fields.iter().map(Field::invoke))),
         ))
@@ -367,26 +392,25 @@ impl Field {
         typ
     }
 
-    fn bounds(&self, buf: &mut String) {
+    fn bounds(&self, buf: &mut TokenStream) {
         let Field { name, kind, .. } = self;
+
+        let mut typ = *name;
+        typ.make_ascii_uppercase();
 
         match kind {
             FieldKind::View | FieldKind::StaticView => {
-                let mut typ = *name;
-                typ.make_ascii_uppercase();
-
-                let _ = write!(buf, "{typ}: ::kobold::View,");
+                buf.write((typ.as_str(), ": ::kobold::View,"));
             }
-            FieldKind::Attribute { attr, .. } => {
-                let mut typ = *name;
-                typ.make_ascii_uppercase();
-
-                let _ = write!(
-                    buf,
-                    "{typ}: ::kobold::attribute::AttributeView<::kobold::attribute::{}>{},",
-                    attr.name,
+            FieldKind::Attribute { attr, span, .. } => {
+                buf.write((
+                    typ.as_str(),
+                    ": ::kobold::attribute::AttributeView<::kobold::attribute::",
+                    Ident::new(attr.name, *span),
+                    '>',
                     attr.abi.map(InlineAbi::bound).unwrap_or(""),
-                );
+                    ',',
+                ));
             }
         }
     }


### PR DESCRIPTION
Pass span information to the type of an attribute in the generic bounds of the `View` implementation of the `Transient` struct in the macros.

All so **rust-analyzer** can do this:
![Screenshot from 2023-03-29 14-52-10](https://user-images.githubusercontent.com/1096222/228560482-7737677a-e67f-4089-9aeb-0dda2e5d0de6.png)
