### PR TITLE
Hint everything

### DIFF
--- a/crates/kobold/src/attribute.rs
+++ b/crates/kobold/src/attribute.rs
@@ -3,6 +3,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 //! Utilities for dealing with DOM attributes
+use std::ops::Deref;
+
 use web_sys::Node;
 
 use crate::diff::{Diff, Ref};
@@ -11,21 +13,35 @@ use crate::internal;
 use crate::value::Value as Text;
 
 /// Arbitrary attribute: <https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute>
-pub type AttributeName = &'static str;
+pub struct AttributeName(str);
 
-impl Property<&str> for AttributeName {
+impl From<&str> for &AttributeName {
+    fn from(attr: &str) -> Self {
+        unsafe { &*(attr as *const _ as *const AttributeName) }
+    }
+}
+
+impl Deref for AttributeName {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Property<&str> for &AttributeName {
     fn set(self, this: &Node, value: &str) {
         internal::set_attr(this, self, value)
     }
 }
 
-impl Property<f64> for AttributeName {
+impl Property<f64> for &AttributeName {
     fn set(self, this: &Node, value: f64) {
         internal::set_attr_num(this, self, value)
     }
 }
 
-impl Property<bool> for AttributeName {
+impl Property<bool> for &AttributeName {
     fn set(self, this: &Node, value: bool) {
         internal::set_attr_bool(this, self, value)
     }

--- a/crates/kobold/src/attribute.rs
+++ b/crates/kobold/src/attribute.rs
@@ -8,7 +8,7 @@ use web_sys::Node;
 use crate::diff::{Diff, Ref};
 use crate::dom::Property;
 use crate::internal;
-use crate::value::Value;
+use crate::value::Value as Text;
 
 /// Arbitrary attribute: <https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute>
 pub type AttributeName = &'static str;
@@ -61,7 +61,7 @@ attribute!(
     /// The `href` attribute: <https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/href>
     Href [href: &str]
     /// The `value` attribute: <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#value>
-    InputValue [value: &str, value_num: f64]
+    Value [value: &str, value_num: f64]
 );
 
 pub trait Attribute<P> {
@@ -99,7 +99,7 @@ where
 
 impl<P> Attribute<P> for bool
 where
-    Self: Value<P>,
+    Self: Text<P>,
 {
     /// `bool` attributes can have weird behavior, it's best to
     /// diff them in the DOM directly
@@ -121,7 +121,7 @@ macro_rules! impl_attribute_view {
         $(
             impl<P> Attribute<P> for $ty
             where
-                Self: Value<P>,
+                Self: Text<P>,
             {
                 type Product = <Self as Diff>::Memo;
 

--- a/crates/kobold/src/internal.rs
+++ b/crates/kobold/src/internal.rs
@@ -13,6 +13,10 @@ use crate::View;
 #[repr(transparent)]
 pub struct Precompiled<F>(pub F);
 
+pub fn fn_type_hint<T, F: Fn(T)>(f: F) -> F {
+    f
+}
+
 impl<F> View for Precompiled<F>
 where
     F: Fn() -> Node,

--- a/crates/kobold/src/value.rs
+++ b/crates/kobold/src/value.rs
@@ -10,7 +10,7 @@ use crate::internal;
 use crate::View;
 
 /// Value that can be set as a property on DOM node
-pub trait Value<P> {
+pub trait Value<P>: IntoText {
     fn set_prop(self, prop: P, node: &Node);
 }
 
@@ -34,7 +34,7 @@ macro_rules! impl_text {
 }
 
 impl_text! {
-    text_node [&str, &String]
+    text_node [&str, &String, &Ref<str>]
     text_node_num [i8, i16, i32, isize, u8, u16, u32, usize, f32, f64]
     text_node_bool [bool]
 }

--- a/crates/kobold_macros/src/dom.rs
+++ b/crates/kobold_macros/src/dom.rs
@@ -53,7 +53,7 @@ pub struct Component {
 pub struct HtmlElement {
     pub name: String,
     pub span: Span,
-    pub classes: Vec<(Span, CssValue)>,
+    pub classes: Vec<CssValue>,
     pub attributes: Vec<Attribute>,
     pub children: Option<Vec<Node>>,
 }
@@ -165,8 +165,8 @@ impl Node {
                 let mut attributes = Vec::new();
 
                 loop {
-                    if let Some(dot) = content.allow_consume('.') {
-                        classes.push((dot.span(), content.parse()?));
+                    if content.allow_consume('.').is_some() {
+                        classes.push(content.parse()?);
                     } else if let Some(hash) = content.allow_consume('#') {
                         let name = Ident::new("id", hash.span());
                         let value: CssValue = content.parse()?;
@@ -184,7 +184,7 @@ impl Node {
                     let attr: Attribute = content.parse()?;
 
                     if attr.name.eq_str("class") {
-                        classes.push((attr.name.span(), CssValue::try_from(attr.value)?));
+                        classes.push(CssValue::try_from(attr.value)?);
                     } else {
                         attributes.push(attr);
                     }

--- a/crates/kobold_macros/src/gen.rs
+++ b/crates/kobold_macros/src/gen.rs
@@ -69,7 +69,7 @@ impl Generator {
     fn add_attr_hint(&mut self, name: Ident, lt: &str, attr: &str) {
         self.add_hint(
             name,
-            format_args!("::kobold::attribute::Attribute<{lt} ::kobold::attribute::{attr}>"),
+            format_args!("impl ::kobold::attribute::Attribute<{lt} ::kobold::attribute::{attr}>"),
         );
     }
 

--- a/crates/kobold_macros/src/gen.rs
+++ b/crates/kobold_macros/src/gen.rs
@@ -59,8 +59,18 @@ impl Generator {
         self.out.fields.last_mut().unwrap()
     }
 
-    fn add_hint(&mut self, name: Ident, typ: TokenStream) {
-        self.out.hints.push(Hint { name, typ });
+    fn add_hint(&mut self, name: Ident, typ: impl Tokenize) {
+        self.out.hints.push(Hint {
+            name,
+            typ: typ.tokenize(),
+        });
+    }
+
+    fn add_attr_hint(&mut self, name: Ident, lt: &str, attr: &str) {
+        self.add_hint(
+            name,
+            format_args!("::kobold::attribute::Attribute<{lt} ::kobold::attribute::{attr}>"),
+        );
     }
 
     fn hoist(&mut self, node: DomNode) -> Option<JsFnName> {

--- a/crates/kobold_macros/src/gen.rs
+++ b/crates/kobold_macros/src/gen.rs
@@ -6,7 +6,7 @@ use std::fmt::{Debug, Write};
 use std::hash::Hash;
 
 use arrayvec::ArrayString;
-use proc_macro::TokenStream;
+use proc_macro::{Ident, TokenStream};
 
 use crate::dom::{Expression, Node};
 use crate::itertools::IteratorExt;
@@ -19,7 +19,7 @@ mod transient;
 
 pub use element::JsElement;
 pub use fragment::{append, JsFragment};
-pub use transient::{Anchor, Field, FieldKind, Transient};
+pub use transient::{Anchor, Field, FieldKind, Hint, Transient};
 pub use transient::{JsArgument, JsFnName, JsFunction, JsModule, JsString};
 
 // Short string for auto-generated variable names
@@ -57,6 +57,10 @@ impl Generator {
 
         self.out.fields.push(Field::new(name, value));
         self.out.fields.last_mut().unwrap()
+    }
+
+    fn add_hint(&mut self, name: Ident, typ: TokenStream) {
+        self.out.hints.push(Hint { name, typ });
     }
 
     fn hoist(&mut self, node: DomNode) -> Option<JsFnName> {

--- a/crates/kobold_macros/src/gen/element.rs
+++ b/crates/kobold_macros/src/gen/element.rs
@@ -171,7 +171,7 @@ impl IntoGenerator for HtmlElement {
                     gen.add_hint(
                         name.clone(),
                         format_args!(
-                            "Fn(\
+                            "impl Fn(\
                                 ::kobold::event::{event}<\
                                     ::kobold::reexport::web_sys::{target}\
                                 >\

--- a/crates/kobold_macros/src/gen/element.rs
+++ b/crates/kobold_macros/src/gen/element.rs
@@ -170,8 +170,8 @@ impl IntoGenerator for HtmlElement {
                     AttributeType::Unknown => {
                         el.hoisted = true;
 
-                        let prop = name.with_str(Literal::string).tokenize();
-                        let attr = Attr::new("AttributeName");
+                        let prop = (name.with_str(Literal::string), ".into()").tokenize();
+                        let attr = Attr::new("&AttributeName");
                         gen.add_field(expr.stream).attr(var, name, attr, prop);
                     }
                 },
@@ -231,6 +231,14 @@ pub struct Attr {
 impl Attr {
     const fn new(name: &'static str) -> Self {
         Attr { name, abi: None }
+    }
+
+    pub fn as_parts(&self) -> (&str, &str) {
+        if self.name.starts_with('&') {
+            ("&'static ", &self.name[1..])
+        } else {
+            ("", self.name)
+        }
     }
 
     fn prop(&self) -> TokenStream {

--- a/crates/kobold_macros/src/gen/element.rs
+++ b/crates/kobold_macros/src/gen/element.rs
@@ -143,38 +143,23 @@ impl IntoGenerator for HtmlElement {
                     AttributeType::Provided(attr) => {
                         el.hoisted = true;
 
-                        gen.add_hint(
-                            name.clone(),
-                            format_args!(
-                                "::kobold::attribute::Attribute<\
-                                    ::kobold::attribute::{}\
-                                >",
-                                attr.name
-                            )
-                            .tokenize(),
-                        );
-
                         let value = gen.add_field(expr.stream).attr(var, attr, attr.prop()).name;
 
                         if let Some(abi) = attr.abi {
                             writeln!(el, "{var}.{name}={value};");
                             el.args.push(JsArgument::with_abi(value, abi))
                         }
+
+                        gen.add_attr_hint(name, "", attr.name);
                     }
                     AttributeType::Unknown => {
                         el.hoisted = true;
 
-                        gen.add_hint(
-                            name.clone(),
-                            "::kobold::attribute::Attribute<\
-                                &'static ::kobold::attribute::AttributeName\
-                            >"
-                            .tokenize(),
-                        );
-
                         let prop = (name.with_str(Literal::string), ".into()").tokenize();
                         let attr = Attr::new("&AttributeName");
+
                         gen.add_field(expr.stream).attr(var, attr, prop);
+                        gen.add_attr_hint(name, "&'static", "AttributeName");
                     }
                 },
             };

--- a/crates/kobold_macros/src/gen/element.rs
+++ b/crates/kobold_macros/src/gen/element.rs
@@ -259,7 +259,7 @@ fn attribute_type(attr: &str) -> AttributeType {
             abi: Some(InlineAbi::Str),
         },
         "value" => Attr {
-            name: "InputValue",
+            name: "Value",
             abi: None,
         },
         _ => return AttributeType::Unknown,

--- a/crates/kobold_macros/src/gen/element.rs
+++ b/crates/kobold_macros/src/gen/element.rs
@@ -124,11 +124,9 @@ impl IntoGenerator for HtmlElement {
                         let event_type = event_js_type(&event);
                         let target = el.typ.clone();
 
-                        let fn_name = name.to_string();
-
-                        let coerce = (
+                        let coerce = block((
                             call(
-                                format_args!("pub fn {fn_name}"),
+                                "pub fn __type_hint",
                                 (
                                     name.clone(),
                                     format_args!(
@@ -146,13 +144,7 @@ impl IntoGenerator for HtmlElement {
                                 >"
                             ),
                             block(name.tokenize()),
-                        )
-                            .tokenize();
-
-                        let coerce = block((
-                            "mod __coerce",
-                            block(coerce),
-                            call(format_args!("__coerce::{fn_name}"), expr.stream),
+                            call("__type_hint", expr.stream),
                         ))
                         .tokenize();
 

--- a/crates/kobold_macros/src/gen/transient.rs
+++ b/crates/kobold_macros/src/gen/transient.rs
@@ -80,7 +80,7 @@ impl Transient {
 
         for field in self.fields.iter() {
             if let FieldKind::Attribute { el, name, attr, .. } = &field.kind {
-                let attr_name = attr.name;
+                let (amp, attr_name) = attr.as_parts();
 
                 stream.write((
                     "#[allow(unused_variables)]",
@@ -91,7 +91,7 @@ impl Transient {
                             format_args!(
                                 ":\
                                     impl ::kobold::attribute::Attribute<\
-                                        ::kobold::attribute::{attr_name}\
+                                        {amp}::kobold::attribute::{attr_name}\
                                     >\
                                 "
                             ),
@@ -466,10 +466,10 @@ impl Field {
                 ));
             }
             FieldKind::Attribute { attr, .. } => {
-                let attr_name = attr.name;
+                let (amp, attr_name) = attr.as_parts();
                 buf.write((
                     format_args!(
-                        "{typ}: ::kobold::attribute::Attribute<::kobold::attribute::{attr_name}>"
+                        "{typ}: ::kobold::attribute::Attribute<{amp}::kobold::attribute::{attr_name}>"
                     ),
                     attr.abi.map(InlineAbi::bound),
                     ',',

--- a/crates/kobold_macros/src/gen/transient.rs
+++ b/crates/kobold_macros/src/gen/transient.rs
@@ -94,7 +94,7 @@ impl Transient {
             let name = hint.name.with_str(|h| Ident::new_raw(h, hint.name.span()));
 
             stream.write((
-                call(format_args!("fn _hint_{i}"), (name, ": impl", hint.typ)),
+                call(format_args!("fn _hint_{i}"), (name, ':', hint.typ)),
                 block(()),
             ))
         }

--- a/crates/kobold_macros/src/gen/transient.rs
+++ b/crates/kobold_macros/src/gen/transient.rs
@@ -379,7 +379,6 @@ pub enum FieldKind {
     Attribute {
         el: Short,
         attr: Attr,
-        name: Ident,
         prop: TokenStream,
     },
 }
@@ -419,13 +418,8 @@ impl Field {
         self
     }
 
-    pub fn attr(&mut self, el: Short, name: Ident, attr: Attr, prop: TokenStream) -> &mut Self {
-        self.kind = FieldKind::Attribute {
-            el,
-            name,
-            attr,
-            prop,
-        };
+    pub fn attr(&mut self, el: Short, attr: Attr, prop: TokenStream) -> &mut Self {
+        self.kind = FieldKind::Attribute { el, attr, prop };
         self
     }
 

--- a/crates/kobold_macros/src/lib.rs
+++ b/crates/kobold_macros/src/lib.rs
@@ -33,6 +33,7 @@ macro_rules! unwrap_err {
     };
 }
 
+#[allow(clippy::let_and_return)]
 #[proc_macro_attribute]
 pub fn component(args: TokenStream, input: TokenStream) -> TokenStream {
     let args = unwrap_err!(fn_component::args(args));

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -19,6 +19,13 @@ fn App() -> impl View {
             let clear = move |_| state.clear();
         }
 
+        {
+            let _ = FilterView::<Filter, _> {
+                filter: Filter::All,
+                state,
+            };
+        }
+
         view! {
             <div .todomvc-wrapper>
                 <section .todoapp>

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -19,13 +19,6 @@ fn App() -> impl View {
             let clear = move |_| state.clear();
         }
 
-        {
-            let _ = FilterView::<Filter, _> {
-                filter: Filter::All,
-                state,
-            };
-        }
-
         view! {
             <div .todomvc-wrapper>
                 <section .todoapp>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1096222/229146842-40bf765c-c2d3-47d1-9b20-cd5649594559.png)

Continuation of the work started in #46, this PR adds hints to _all_ DOM element attributes, including those that are statically compiled into JS. This is done by generating dead code such as:

```rust
#[allow(unused_variables)]
{
   fn _hint_0(href: impl Attribute<Href>) {}
}
```
The param of the hint function (`href` here) is spanned to the attribute in the `view!` macro, effectively tricking **rust-analyzer** into providing a hint for the type (even if the value is never instantiated in Rust to begin with).