### PR TITLE
Example of using the `get` function implementation of `Hook`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 target
 **/*.rs.bk
 examples/*/dist
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,11 @@ dependencies = [
 name = "kobold_hello_world_example"
 version = "0.1.0"
 dependencies = [
+ "gloo-storage",
  "kobold",
+ "log",
+ "wasm-bindgen",
+ "wasm-logger",
 ]
 
 [[package]]
@@ -450,6 +454,17 @@ name = "wasm-bindgen-shared"
 version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+
+[[package]]
+name = "wasm-logger"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "074649a66bb306c8f2068c9016395fa65d8e08d2affcbf95acf3c24c3ab19718"
+dependencies = [
+ "log",
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -5,3 +5,7 @@ edition = "2021"
 
 [dependencies]
 kobold = { path = "../../crates/kobold" }
+gloo-storage = "0.2.1"
+log = "0.4.17"
+wasm-bindgen = "0.2.84"
+wasm-logger = "0.2.0"

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -6,15 +6,16 @@ mod state;
 use state::{State};
 
 #[component]
-fn Hello(state: bool) -> impl View + 'static {
-    stateful(State::mock, |state| {
+fn Hello(new_state: bool) -> impl View + 'static {
+    stateful(State::mock, move |state| {
         let signal: Signal<State> = state.signal();
 
         let s = state.get();
         debug!("my_state {:#?}", s);
 
         signal.update(|state| state.toggle());
-        signal.set(State { my_state: true });
+
+        signal.set(State { my_state: new_state });
         debug!("my_state new {:#?}", s);
         let s_new = state.get();
         debug!("my_state new {:#?}", s_new);
@@ -30,6 +31,6 @@ fn Hello(state: bool) -> impl View + 'static {
 fn main() {
     wasm_logger::init(wasm_logger::Config::default());
     kobold::start(view! {
-        <Hello state=true />
+        <Hello new_state=true />
     });
 }

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -1,14 +1,35 @@
 use kobold::prelude::*;
+use log::{debug};
+
+mod state;
+
+use state::{State};
 
 #[component]
-fn Hello(name: &str) -> impl View + '_ {
-    view! {
-        <h1>"Hello "{ name }"!"</h1>
-    }
+fn Hello(state: bool) -> impl View + 'static {
+    stateful(State::mock, |state| {
+        let signal: Signal<State> = state.signal();
+
+        let s = state.get();
+        debug!("my_state {:#?}", s);
+
+        signal.update(|state| state.toggle());
+        signal.set(State { my_state: true });
+        debug!("my_state new {:#?}", s);
+        let s_new = state.get();
+        debug!("my_state new {:#?}", s_new);
+        let s_more = State::get();
+        debug!("my_state more {:#?}", s_more);
+
+        view! {
+            <h1>"Hello "{ use s.my_state }"!"</h1>
+        }
+    })
 }
 
 fn main() {
+    wasm_logger::init(wasm_logger::Config::default());
     kobold::start(view! {
-        <Hello name="Kobold" />
+        <Hello state=true />
     });
 }

--- a/examples/hello_world/src/state.rs
+++ b/examples/hello_world/src/state.rs
@@ -62,7 +62,7 @@ impl State {
     pub fn toggle(&mut self) {
         self.my_state = !self.my_state;
 
-        // self.store();
-        State::store(self);
+        self.store();
+        // State::store(self);
     }
 }

--- a/examples/hello_world/src/state.rs
+++ b/examples/hello_world/src/state.rs
@@ -1,0 +1,68 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use gloo_storage::{LocalStorage, Storage};
+use wasm_bindgen::throw_str;
+use log::{debug};
+
+const KEY: &str = "kobold.hello_world.example";
+
+#[derive(Clone, Copy, Debug)]
+pub struct State {
+    pub my_state: bool,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        let mut my_state = false;
+        if let Some(storage) = LocalStorage::raw().get(KEY).ok() {
+            my_state = storage.unwrap().parse::<bool>().is_err();
+        }
+
+        State {
+            my_state
+        }
+    }
+}
+
+impl State {
+    pub fn mock() -> Self {
+        State {
+            my_state: false
+        }
+    }
+
+    pub fn get() -> Self {
+        let mut current_state = false;
+        if let Some(storage) = LocalStorage::raw().get(KEY).ok() {
+            if !storage.is_none() {
+                current_state = storage.unwrap().parse::<bool>().is_err();
+            }  else {
+                debug!("my_state is None in storage");
+            }
+        } else {
+            debug!("my_state is None in storage");
+        }
+
+        State {
+            my_state: current_state
+        }
+    }
+
+    #[inline(never)]
+    pub fn store(&mut self) {
+        let mut storage = false;
+
+        storage = self.my_state;
+
+        LocalStorage::raw().set_item(KEY, &storage.to_string()).ok();
+    }
+
+    pub fn toggle(&mut self) {
+        self.my_state = !self.my_state;
+
+        // self.store();
+        State::store(self);
+    }
+}


### PR DESCRIPTION
Example of using the `get` function implementation of `Hook` https://docs.rs/kobold/latest/kobold/stateful/struct.Hook.html#method.get, which states _"Get the value of state if state implements Copy"_, where I've used a state that is just a struct `State` that has a `my_state` property with a `bool` type so it can implement the `Copy` trait, since if the `State` has properties of types that don't automatically implement the `Copy` trait (i.e. `Vec`, `String`, `Range`, `Box`) then you get errors like:
```
error[E0204]: the trait `Copy` may not be implemented for this type
  --> examples/invoice/src/state.rs:33:32
   |
33 | #[derive(PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize)]
   |                                ^^^^
...
39 |     pub qr_code: String,
   |     ------------------- this field does not implement `Copy`
   |
   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0204]: the trait `Copy` may not be implemented for this type
  --> examples/invoice/src/state.rs:41:32
   |
41 | #[derive(PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize)]
   |                                ^^^^
42 | pub struct Entry {
43 |     pub description: String,
   |     ----------------------- this field does not implement `Copy`
   |
   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0204]: the trait `Copy` may not be implemented for this type
  --> examples/invoice/src/state.rs:47:32
   |
47 | #[derive(PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize)]
   |                                ^^^^
...
50 |     pub columns: Vec<Text>,
   |     ---------------------- this field does not implement `Copy`
51 |     pub rows: Vec<Vec<Text>>,
   |     ------------------------ this field does not implement `Copy`
   |
   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0204]: the trait `Copy` may not be implemented for this type
  --> examples/invoice/src/state.rs:54:32
   |
54 | #[derive(PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize)]
   |                                ^^^^
55 | pub enum Text {
56 |     Insitu(Range<usize>),
   |            ------------ this field does not implement `Copy`
57 |     Owned(Box<str>),
   |           -------- this field does not implement `Copy`
   |
   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0204]: the trait `Copy` may not be implemented for this type
   --> examples/invoice/src/state.rs:204:32
    |
204 | #[derive(PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize)]
    |                                ^^^^
205 | pub struct TextSource {
206 |     pub source: String,
    |     ------------------ this field does not implement `Copy`
```

But if i try to use `stateful::Signal` public function `.set`  https://docs.rs/kobold/latest/kobold/stateful/struct.Signal.html#method.set, which says it's used to  _"Replace the entire state with a new value and trigger an update."_, it doesn't change the state at all as expected, i thought it would have set the `my_state` value to `true`

<img width="1331" alt="Screen Shot 2023-04-04 at 12 24 31 pm" src="https://user-images.githubusercontent.com/6226175/229672945-e580e59f-4144-47e4-9e5d-e6c8cd9d108b.png">
