### PR TITLE
Update csv_editor with rotated table option 

### DIFF
--- a/examples/csv_editor/index.html
+++ b/examples/csv_editor/index.html
@@ -13,8 +13,28 @@
         table-layout: fixed;
       }
 
+      thead.rotate {
+        float: left;
+      }
+
+      thead.rotate th {
+        display: block;
+      }
+
       th {
         background: #eee;
+      }
+
+      tbody.rotate {
+        float: right;
+      }
+
+      tbody.rotate tr {
+        display: inline-block;
+      }
+
+      tbody.rotate td {
+        display: block;
       }
 
       td, th, input.edit {

--- a/examples/csv_editor/src/main.rs
+++ b/examples/csv_editor/src/main.rs
@@ -47,14 +47,14 @@ fn Editor() -> impl View {
             <input type="file" accept="text/csv" onchange={onload} />
             <h1>{ ref state.name }</h1>
             <table {onkeydown}>
-                <thead>
+                <thead.rotate>
                     <tr>
                     {
                         for state.columns().map(|col| view! { <Head {col} {state} /> })
                     }
                     </tr>
                 </thead>
-                <tbody>
+                <tbody.rotate>
                 {
                     for state.rows().map(move |row| view! {
                         <tr>


### PR DESCRIPTION
use CSS to rotate table so it's shown as:

<img width="160" alt="Screen Shot 2023-04-05 at 5 07 59 pm" src="https://user-images.githubusercontent.com/6226175/230006947-698eb66a-19dc-4968-b2c4-7512bbe8d403.png">

instead of as:

<img width="157" alt="Screen Shot 2023-04-05 at 5 10 41 pm" src="https://user-images.githubusercontent.com/6226175/230007271-3c99dafd-c02d-4a2d-9d8c-ff739b6df8e0.png">

reference: https://stackoverflow.com/a/5800696