### PR TITLE
Optional closing tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ dependencies = [
  "arrayvec",
  "beef",
  "fnv",
+ "once_cell",
  "proc-macro2",
 ]
 

--- a/crates/kobold/src/event.rs
+++ b/crates/kobold/src/event.rs
@@ -90,14 +90,14 @@ where
 
 impl<E, F> Listener<E> for F
 where
-    F: Fn(E) + 'static,
+    F: FnMut(E) + 'static,
     E: hidden::EventCast,
 {
     fn build(self) -> ListenerProduct<Self> {
         let raw = Box::into_raw(Box::new(self));
 
         let js = Closure::wrap(unsafe {
-            Box::from_raw(raw as *mut dyn Fn(E) as *mut dyn Fn(web_sys::Event))
+            Box::from_raw(raw as *mut dyn FnMut(E) as *mut dyn FnMut(web_sys::Event))
         })
         .into_js_value();
 

--- a/crates/kobold/src/internal.rs
+++ b/crates/kobold/src/internal.rs
@@ -13,7 +13,7 @@ use crate::View;
 #[repr(transparent)]
 pub struct Precompiled<F>(pub F);
 
-pub fn fn_type_hint<T, F: Fn(T)>(f: F) -> F {
+pub fn fn_type_hint<T, F: FnMut(T)>(f: F) -> F {
     f
 }
 

--- a/crates/kobold_macros/Cargo.toml
+++ b/crates/kobold_macros/Cargo.toml
@@ -15,6 +15,7 @@ documentation = "https://docs.rs/kobold"
 arrayvec = "0.7.2"
 beef = "0.5.2"
 fnv = "1.0.7"
+once_cell = "1.17.1"
 
 [dev-dependencies]
 proc-macro2 = "1.0.51"

--- a/crates/kobold_macros/src/dom.rs
+++ b/crates/kobold_macros/src/dom.rs
@@ -10,6 +10,7 @@ use crate::tokenize::prelude::*;
 
 mod expression;
 mod shallow;
+mod els;
 
 pub use expression::Expression;
 pub use shallow::{ShallowNode, ShallowNodeIter, ShallowStream, TagName, TagNesting};

--- a/crates/kobold_macros/src/dom.rs
+++ b/crates/kobold_macros/src/dom.rs
@@ -14,6 +14,7 @@ mod els;
 
 pub use expression::Expression;
 pub use shallow::{ShallowNode, ShallowNodeIter, ShallowStream, TagName, TagNesting};
+pub use els::ElementTag;
 
 pub fn parse(tokens: TokenStream) -> Result<Vec<Node>, ParseError> {
     let mut stream = tokens.parse_stream().into_shallow_stream();
@@ -52,7 +53,7 @@ pub struct Component {
 
 #[derive(Debug)]
 pub struct HtmlElement {
-    pub name: String,
+    pub name: ElementTag,
     pub span: Span,
     pub classes: Vec<CssValue>,
     pub attributes: Vec<Attribute>,

--- a/crates/kobold_macros/src/dom.rs
+++ b/crates/kobold_macros/src/dom.rs
@@ -219,12 +219,7 @@ impl Node {
 
             match Node::parse(stream)? {
                 Some(node) => children.push(node),
-                None => {
-                    return Err(ParseError::new(
-                        format!("Missing closing tag for {name}"),
-                        name.span(),
-                    ))
-                }
+                None => break,
             }
         }
 

--- a/crates/kobold_macros/src/dom/els.rs
+++ b/crates/kobold_macros/src/dom/els.rs
@@ -1,0 +1,190 @@
+macro_rules! enum_map {
+    (
+        pub static $MAP:ident: [$out:ident] for $enum:ident {
+            $($variant:ident => $args:tt,)*
+        }
+    ) => {
+        #[derive(Clone, Copy)]
+        pub enum $enum {
+            $($variant,)*
+        }
+
+        pub static $MAP: [$out; 0 $(+ { let _ = $enum::$variant; 1 })*] = [
+            $($out::new $args,)*
+        ];
+    };
+}
+
+pub enum ClosingRules {
+    /// Void element, no closing tag, e.g. `<img>` or `<br>`
+    Void,
+    /// Required closing tag, e.g. `<div>`
+    Required,
+    /// Optional closing tag plus opening tags that close this if any, e.g. `<li>`
+    Optional(&'static [El]),
+}
+
+pub struct ElDefinition {
+    name: TagStr,
+    closing: ClosingRules,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct TagStr {
+    bytes: [u8; 15],
+    len: u8,
+}
+
+#[rustfmt::skip]
+const fn tagstr<const N: usize>(input: &[u8; N]) -> TagStr {
+    let mut bytes = [0u8; 15];
+
+    if 0 < N { bytes[0] = input[0]; }
+    if 1 < N { bytes[1] = input[1]; }
+    if 2 < N { bytes[2] = input[2]; }
+    if 3 < N { bytes[3] = input[3]; }
+    if 4 < N { bytes[4] = input[4]; }
+    if 5 < N { bytes[5] = input[5]; }
+    if 6 < N { bytes[6] = input[6]; }
+    if 7 < N { bytes[7] = input[7]; }
+    if 8 < N { bytes[8] = input[8]; }
+    if 9 < N { bytes[9] = input[9]; }
+    if 10 < N { bytes[10] = input[10]; }
+    if 11 < N { bytes[11] = input[11]; }
+    if 12 < N { bytes[12] = input[12]; }
+    if 13 < N { bytes[13] = input[13]; }
+    if 14 < N { bytes[14] = input[14]; }
+
+    TagStr {
+        bytes,
+        len: N as u8,
+    }
+}
+
+impl ElDefinition {
+    const fn new<const N: usize>(name: &'static [u8; N], closing: ClosingRules) -> Self {
+        ElDefinition {
+            name: tagstr(name),
+            closing,
+        }
+    }
+}
+
+use ClosingRules::*;
+
+enum_map! {
+    pub static ELS: [ElDefinition] for El {
+        Anchor => (b"a", Required),
+        Abbr => (b"abbr", Required),
+        Address => (b"address", Required),
+        Area => (b"area", Void),
+        Article => (b"article", Required),
+        Aside => (b"aside", Required),
+        Audio => (b"audio", Required),
+        Bold => (b"b", Required),
+        Base => (b"base", Void),
+        Bdi => (b"bdi", Required),
+        Bdo => (b"bdo", Required),
+        Blockquote => (b"blockquote", Required),
+        Body => (b"body", Optional(&[])),
+        Br => (b"br", Void),
+        Button => (b"button", Required),
+        Canvas => (b"canvas", Required),
+        Caption => (b"caption", Optional(&[])),
+        Cite => (b"cite", Required),
+        Code => (b"code", Required),
+        Col => (b"col", Void),
+        ColGroup => (b"colgroup", Optional(&[])),
+        Data => (b"data", Required),
+        DataList => (b"datalist", Required),
+        Dd => (b"dd", Optional(&[El::Dd, El::Dt])),
+        Del => (b"del", Required),
+        Definition => (b"dfn", Required),
+        Details => (b"details", Required),
+        Dialog => (b"dialog", Required),
+        Div => (b"div", Required),
+        Dl => (b"dl", Required),
+        Dt => (b"dt", Optional(&[El::Dd, El::Dt])),
+        Em => (b"em", Required),
+        Embed => (b"embed", Void),
+        FieldSet => (b"fieldset", Required),
+        FigCaption => (b"figcaption", Required),
+        Figure => (b"figure", Required),
+        Footer => (b"footer", Required),
+        Form => (b"form", Required),
+        Head => (b"head", Optional(&[])),
+        Header => (b"header", Required),
+        Header1 => (b"h1", Required),
+        Header2 => (b"h1", Required),
+        Header3 => (b"h1", Required),
+        Header4 => (b"h1", Required),
+        Header5 => (b"h1", Required),
+        Header6 => (b"h1", Required),
+        HGroup => (b"hgroup", Required),
+        Hr => (b"hr", Void),
+        Html => (b"html", Optional(&[])),
+        Italic => (b"i", Required),
+        IFrame => (b"iframe", Required),
+        Img => (b"img", Void),
+        Input => (b"input", Void),
+        Ins => (b"ins", Required),
+        Kbd => (b"kbd", Required),
+        Label => (b"label", Required),
+        Legend => (b"legend", Required),
+        Li => (b"li", Optional(&[El::Li])),
+        Link => (b"link", Void),
+        Main => (b"main", Required),
+        Map => (b"map", Required),
+        Mark => (b"mark", Required),
+        Menu => (b"menu", Required),
+        Meta => (b"meta", Void),
+        Meter => (b"meter", Required),
+        Nav => (b"nav", Required),
+        NoScript => (b"noscript", Required),
+        Object => (b"object", Required),
+        Ol => (b"ol", Required),
+        OptGroup => (b"optgroup", Optional(&[El::OptGroup])),
+        Option => (b"option", Optional(&[El::Option, El::OptGroup])),
+        Output => (b"output", Required),
+        Paragraph => (b"p", Optional(&[El::Paragraph])),
+        Picture => (b"picture", Required),
+        Pre => (b"pre", Required),
+        Progress => (b"progress", Required),
+        Quote => (b"q", Required),
+        Rp => (b"rp", Optional(&[El::Rp, El::Rt])),
+        Rt => (b"rt", Optional(&[El::Rp, El::Rt])),
+        Ruby => (b"ruby", Required),
+        Strike => (b"s", Required),
+        Samp => (b"samp", Required),
+        Script => (b"script", Required),
+        Section => (b"section", Required),
+        Select => (b"select", Required),
+        Slot => (b"slot", Required),
+        Small => (b"small", Required),
+        Source => (b"source", Void),
+        Span => (b"span", Required),
+        Strong => (b"strong", Required),
+        Style => (b"style", Required),
+        Sub => (b"sub", Required),
+        Summary => (b"summary", Required),
+        Sup => (b"sup", Required),
+        Table => (b"table", Required),
+        Tbody => (b"tbody", Optional(&[El::Tbody, El::Tfoot])),
+        Td => (b"td", Optional(&[El::Td, El::Th])),
+        Template => (b"template", Required),
+        TextArea => (b"textarea", Required),
+        Tfoot => (b"tfoot", Optional(&[])),
+        Th => (b"th", Optional(&[El::Td, El::Th])),
+        Thead => (b"thead", Optional(&[El::Tbody, El::Tfoot])),
+        Time => (b"time", Required),
+        Title => (b"title", Required),
+        Tr => (b"tr", Optional(&[El::Tr])),
+        Track => (b"track", Required),
+        Underline => (b"u", Required),
+        Ul => (b"ul", Required),
+        Var => (b"var", Required),
+        Video => (b"video", Required),
+        Wbr => (b"wbr", Void),
+    }
+}

--- a/crates/kobold_macros/src/dom/els.rs
+++ b/crates/kobold_macros/src/dom/els.rs
@@ -1,16 +1,17 @@
-use std::ops::Deref;
 use std::fmt::{self, Debug};
+use std::ops::Deref;
 
 use fnv::FnvHashMap;
 use once_cell::sync::Lazy;
 
 macro_rules! build_tags {
     (
-        $($variant:ident $tag:literal $closing:tt)*
+        $($variant:ident $tag:literal $closing:expr;)*
     ) => {
         const VARIANTS: usize = 0 $(+ { let _ = ElementTag::$variant; 1 })*;
 
         #[derive(Clone, Copy, PartialEq, Eq)]
+        #[repr(u8)]
         pub enum ElementTag {
             $($variant,)*
         }
@@ -19,7 +20,7 @@ macro_rules! build_tags {
 
         static CLOSING: [ClosingRules; VARIANTS] = [$(closing!($closing),)*];
 
-        static TAG_BY_NAME: Lazy<FnvHashMap<&'static str, ElementTag>> = Lazy::new(|| {
+        static TAG_BY_NAME: Lazy<FnvHashMap<&str, ElementTag>> = Lazy::new(|| {
             let mut m = FnvHashMap::default();
             $(
                 m.insert($tag, ElementTag::$variant);
@@ -36,32 +37,61 @@ impl Debug for ElementTag {
 }
 
 macro_rules! closing {
-    (_) => {ClosingRules::Required};
-    (/) => {ClosingRules::Void};
-    ([$($tag:ident)*]) => {ClosingRules::Optional(&[$(ElementTag::$tag,)*])};
+    (_) => {
+        ClosingRules::Standard
+    };
+    ($e:expr) => {
+        $e
+    };
 }
 
-#[derive(Clone, Copy)]
-pub enum ClosingRules {
-    /// Void element, no closing tag, e.g. `<img>` or `<br>`
-    Void,
-    /// Required closing tag, e.g. `<div>`
-    Required,
-    /// Optional closing tag plus opening tags that close this if any, e.g. `<li>`
-    Optional(&'static [ElementTag]),
+enum ClosingRules {
+    /// No special rules apply
+    Standard,
+    /// Element can have no children and no closing tag, e.g. `<img>` or `<br>`
+    ForbidsChildren,
+    /// Closes if a tag with a specific name is encountered
+    ClosesOn(ElementTag),
+    /// Closes on either of the two tags
+    ClosesOn2([ElementTag; 2]),
+    /// Closes on either of the three tags
+    ClosesOn3([ElementTag; 3]),
+    /// Closes on either of the five tags
+    ClosesOn5([ElementTag; 5]),
+    /// Closes on one of many tags: https://html.spec.whatwg.org/#the-p-element
+    ClosesOnParagraph,
 }
 
 impl ElementTag {
     pub fn from_str(tag: &str) -> Option<Self> {
-        TAG_BY_NAME.get(tag).copied()
-    }
-
-    pub fn closing(self) -> ClosingRules {
-        CLOSING[self as usize]
+        thread_local! {
+            // Make a thread-local reference to avoid going through a sync lock on each call
+            static LOCAL_TAG_BY_NAME: &'static FnvHashMap<&'static str, ElementTag> = &TAG_BY_NAME;
+        }
+        LOCAL_TAG_BY_NAME.with(|map| map.get(tag).copied())
     }
 
     pub fn forbids_children(self) -> bool {
-        matches!(self.closing(), ClosingRules::Void)
+        matches!(CLOSING[self as usize], ClosingRules::ForbidsChildren)
+    }
+
+    pub fn closes_on(self, other: ElementTag) -> bool {
+        use ElementTag::*;
+
+        let tags = match &CLOSING[self as usize] {
+            ClosesOn(tag) => std::slice::from_ref(tag),
+            ClosesOn2(tags) => tags,
+            ClosesOn3(tags) => tags,
+            ClosesOn5(tags) => tags,
+            ClosesOnParagraph => &[
+                Address, Article, Aside, Blockquote, Details, Div, Dl, FieldSet, FigCaption,
+                Figure, Footer, Form, Header, Header1, Header2, Header3, Header4, Header5, Header6,
+                HGroup, Hr, Main, Menu, Nav, Ol, Paragraph, Pre, Search, Section, Table, Ul,
+            ],
+            _ => return false,
+        };
+
+        tags.contains(&other)
     }
 }
 
@@ -73,123 +103,124 @@ impl Deref for ElementTag {
     }
 }
 
+const __: ClosingRules = ClosingRules::Standard;
+
+use ClosingRules::*;
+
+use ElementTag::{Tbody, Td, Tfoot, Th, Tr};
+
 #[rustfmt::skip]
 build_tags! {
-    Anchor      "a"             _
-    Abbr        "abbr"          _
-    Address     "address"       _
-    Area        "area"          /
-    Article     "article"       _
-    Aside       "aside"         _
-    Audio       "audio"         _
-    Bold        "b"             _
-    Base        "base"          /
-    Bdi         "bdi"           _
-    Bdo         "bdo"           _
-    Blockquote  "blockquote"    _
-    Body        "body"          []
-    Br          "br"            /
-    Button      "button"        _
-    Canvas      "canvas"        _
-    Caption     "caption"       []
-    Cite        "cite"          _
-    Code        "code"          _
-    Col         "col"           /
-    ColGroup    "colgroup"      []
-    Data        "data"          _
-    DataList    "datalist"      _
-    Dd          "dd"            [Dd Dt]
-    Del         "del"           _
-    Definition  "dfn"           _
-    Details     "details"       _
-    Dialog      "dialog"        _
-    Div         "div"           _
-    Dl          "dl"             _
-    Dt          "dt"            [Dd Dt]
-    Em          "em"            _
-    Embed       "embed"         /
-    FieldSet    "fieldset"      _
-    FigCaption  "figcaption"    _
-    Figure      "figure"        _
-    Footer      "footer"        _
-    Form        "form"          _
-    Head        "head"          []
-    Header      "header"        _
-    Header1     "h1"            _
-    Header2     "h2"            _
-    Header3     "h3"            _
-    Header4     "h4"            _
-    Header5     "h5"            _
-    Header6     "h6"            _
-    HGroup      "hgroup"        _
-    Hr          "hr"            /
-    Html        "html"          []
-    Italic      "i"             _
-    IFrame      "iframe"        _
-    Img         "img"           /
-    Input       "input"         /
-    Ins         "ins"           _
-    Kbd         "kbd"           _
-    Label       "label"         _
-    Legend      "legend"        _
-    Li          "li"            [Li]
-    Link        "link"          /
-    Main        "main"          _
-    Map         "map"           _
-    Mark        "mark"          _
-    Menu        "menu"          _
-    Meta        "meta"          /
-    Meter       "meter"         _
-    Nav         "nav"           _
-    NoScript    "noscript"      _
-    Object      "object"        _
-    Ol          "ol"            _
-    OptGroup    "optgroup"      [OptGroup]
-    Option      "option"        [Option OptGroup]
-    Output      "output"        _
-    Paragraph   "p"             [
-                                    Paragraph Address Article Aside Blockquote Details Div
-                                    Dl FieldSet FigCaption Figure Footer Form Header
-                                    Header1 Header2 Header3 Header4 Header5 Header6 HGroup
-                                    Hr Main Menu Nav Ol Pre Search Section Table Ul
-                                ]
-    Picture     "picture"       _
-    Pre         "pre"           _
-    Progress    "progress"      _
-    Quote       "q"             _
-    Rp          "rp"            [Rp Rt]
-    Rt          "rt"            [Rp Rt]
-    Ruby        "ruby"          _
-    Strike      "s"             _
-    Samp        "samp"          _
-    Search      "search"        _
-    Script      "script"        _
-    Section     "section"       _
-    Select      "select"        _
-    Slot        "slot"          _
-    Small       "small"         _
-    Source      "source"        /
-    Span        "span"          _
-    Strong      "strong"        _
-    Style       "style"         _
-    Sub         "su"            _
-    Summary     "summary"       _
-    Sup         "sup"           _
-    Table       "table"         _
-    Tbody       "tbody"         [Tbody Tfoot]
-    Td          "td"            [Td Th]
-    Template    "template"      _
-    TextArea    "textarea"      _
-    Tfoot       "tfoot"         []
-    Th          "th"            [Td Th]
-    Thead       "thead"         [Tbody Tfoot]
-    Time        "time"          _
-    Title       "title"         _
-    Tr          "tr"            [Tr]
-    Track       "track"         /
-    Underline   "u"             _
-    Ul          "ul"            _
-    Var         "var"           _
-    Video       "video"         _
-    Wbr         "wbr"           /
+    Anchor      "a"             __;
+    Abbr        "abbr"          __;
+    Address     "address"       __;
+    Area        "area"          ForbidsChildren;
+    Article     "article"       __;
+    Aside       "aside"         __;
+    Audio       "audio"         __;
+    Bold        "b"             __;
+    Base        "base"          ForbidsChildren;
+    Bdi         "bdi"           __;
+    Bdo         "bdo"           __;
+    Blockquote  "blockquote"    __;
+    Body        "body"          __;
+    Br          "br"            ForbidsChildren;
+    Button      "button"        __;
+    Canvas      "canvas"        __;
+    Caption     "caption"       __;
+    Cite        "cite"          __;
+    Code        "code"          __;
+    Col         "col"           ForbidsChildren;
+    ColGroup    "colgroup"      __;
+    Data        "data"          __;
+    DataList    "datalist"      __;
+    Dd          "dd"            ClosesOn2([ElementTag::Dd, ElementTag::Dt]);
+    Del         "del"           __;
+    Definition  "dfn"           __;
+    Details     "details"       __;
+    Dialog      "dialog"        __;
+    Div         "div"           __;
+    Dl          "dl"             __;
+    Dt          "dt"            ClosesOn2([ElementTag::Dd, ElementTag::Dt]);
+    Em          "em"            __;
+    Embed       "embed"         ForbidsChildren;
+    FieldSet    "fieldset"      __;
+    FigCaption  "figcaption"    __;
+    Figure      "figure"        __;
+    Footer      "footer"        __;
+    Form        "form"          __;
+    Head        "head"          __;
+    Header      "header"        __;
+    Header1     "h1"            __;
+    Header2     "h2"            __;
+    Header3     "h3"            __;
+    Header4     "h4"            __;
+    Header5     "h5"            __;
+    Header6     "h6"            __;
+    HGroup      "hgroup"        __;
+    Hr          "hr"            ForbidsChildren;
+    Html        "html"          __;
+    Italic      "i"             __;
+    IFrame      "iframe"        __;
+    Img         "img"           ForbidsChildren;
+    Input       "input"         ForbidsChildren;
+    Ins         "ins"           __;
+    Kbd         "kbd"           __;
+    Label       "label"         __;
+    Legend      "legend"        __;
+    Li          "li"            ClosesOn(ElementTag::Li);
+    Link        "link"          ForbidsChildren;
+    Main        "main"          __;
+    Map         "map"           __;
+    Mark        "mark"          __;
+    Menu        "menu"          __;
+    Meta        "meta"          ForbidsChildren;
+    Meter       "meter"         __;
+    Nav         "nav"           __;
+    NoScript    "noscript"      __;
+    Object      "object"        __;
+    Ol          "ol"            __;
+    OptGroup    "optgroup"      ClosesOn(ElementTag::OptGroup);
+    Option      "option"        ClosesOn2([ElementTag::Option, ElementTag::OptGroup]);
+    Output      "output"        __;
+    Paragraph   "p"             ClosesOnParagraph;
+    Picture     "picture"       __;
+    Pre         "pre"           __;
+    Progress    "progress"      __;
+    Quote       "q"             __;
+    Rp          "rp"            ClosesOn2([ElementTag::Rp, ElementTag::Rt]);
+    Rt          "rt"            ClosesOn2([ElementTag::Rp, ElementTag::Rt]);
+    Ruby        "ruby"          __;
+    Strike      "s"             __;
+    Samp        "samp"          __;
+    Search      "search"        __;
+    Script      "script"        __;
+    Section     "section"       __;
+    Select      "select"        __;
+    Slot        "slot"          __;
+    Small       "small"         __;
+    Source      "source"        ForbidsChildren;
+    Span        "span"          __;
+    Strong      "strong"        __;
+    Style       "style"         __;
+    Sub         "su"            __;
+    Summary     "summary"       __;
+    Sup         "sup"           __;
+    Table       "table"         __;
+    Tbody       "tbody"         ClosesOn2([Tbody, Tfoot]);
+    Td          "td"            ClosesOn5([Td, Th, Tr, Tbody, Tfoot]);
+    Template    "template"      __;
+    TextArea    "textarea"      __;
+    Tfoot       "tfoot"         __;
+    Th          "th"            ClosesOn5([Td, Th, Tr, Tbody, Tfoot]);
+    Thead       "thead"         ClosesOn2([Tbody, Tfoot]);
+    Time        "time"          __;
+    Title       "title"         __;
+    Tr          "tr"            ClosesOn3([Tr, Tbody, Tfoot]);
+    Track       "track"         ForbidsChildren;
+    Underline   "u"             __;
+    Ul          "ul"            __;
+    Var         "var"           __;
+    Video       "video"         __;
+    Wbr         "wbr"           ForbidsChildren;
 }

--- a/crates/kobold_macros/src/dom/els.rs
+++ b/crates/kobold_macros/src/dom/els.rs
@@ -1,190 +1,195 @@
-macro_rules! enum_map {
+use std::ops::Deref;
+use std::fmt::{self, Debug};
+
+use fnv::FnvHashMap;
+use once_cell::sync::Lazy;
+
+macro_rules! build_tags {
     (
-        pub static $MAP:ident: [$out:ident] for $enum:ident {
-            $($variant:ident => $args:tt,)*
-        }
+        $($variant:ident $tag:literal $closing:tt)*
     ) => {
-        #[derive(Clone, Copy)]
-        pub enum $enum {
+        const VARIANTS: usize = 0 $(+ { let _ = ElementTag::$variant; 1 })*;
+
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        pub enum ElementTag {
             $($variant,)*
         }
 
-        pub static $MAP: [$out; 0 $(+ { let _ = $enum::$variant; 1 })*] = [
-            $($out::new $args,)*
-        ];
+        static TAGS: [&str; VARIANTS] = [$($tag,)*];
+
+        static CLOSING: [ClosingRules; VARIANTS] = [$(closing!($closing),)*];
+
+        static TAG_BY_NAME: Lazy<FnvHashMap<&'static str, ElementTag>> = Lazy::new(|| {
+            let mut m = FnvHashMap::default();
+            $(
+                m.insert($tag, ElementTag::$variant);
+            )*
+            m
+        });
     };
 }
 
+impl Debug for ElementTag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self)
+    }
+}
+
+macro_rules! closing {
+    (_) => {ClosingRules::Required};
+    (/) => {ClosingRules::Void};
+    ([$($tag:ident)*]) => {ClosingRules::Optional(&[$(ElementTag::$tag,)*])};
+}
+
+#[derive(Clone, Copy)]
 pub enum ClosingRules {
     /// Void element, no closing tag, e.g. `<img>` or `<br>`
     Void,
     /// Required closing tag, e.g. `<div>`
     Required,
     /// Optional closing tag plus opening tags that close this if any, e.g. `<li>`
-    Optional(&'static [El]),
+    Optional(&'static [ElementTag]),
 }
 
-pub struct ElDefinition {
-    name: TagStr,
-    closing: ClosingRules,
+impl ElementTag {
+    pub fn from_str(tag: &str) -> Option<Self> {
+        TAG_BY_NAME.get(tag).copied()
+    }
+
+    pub fn closing(self) -> ClosingRules {
+        CLOSING[self as usize]
+    }
+
+    pub fn forbids_children(self) -> bool {
+        matches!(self.closing(), ClosingRules::Void)
+    }
 }
 
-#[derive(Clone, Copy)]
-#[repr(C)]
-pub struct TagStr {
-    bytes: [u8; 15],
-    len: u8,
+impl Deref for ElementTag {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        TAGS[*self as usize]
+    }
 }
 
 #[rustfmt::skip]
-const fn tagstr<const N: usize>(input: &[u8; N]) -> TagStr {
-    let mut bytes = [0u8; 15];
-
-    if 0 < N { bytes[0] = input[0]; }
-    if 1 < N { bytes[1] = input[1]; }
-    if 2 < N { bytes[2] = input[2]; }
-    if 3 < N { bytes[3] = input[3]; }
-    if 4 < N { bytes[4] = input[4]; }
-    if 5 < N { bytes[5] = input[5]; }
-    if 6 < N { bytes[6] = input[6]; }
-    if 7 < N { bytes[7] = input[7]; }
-    if 8 < N { bytes[8] = input[8]; }
-    if 9 < N { bytes[9] = input[9]; }
-    if 10 < N { bytes[10] = input[10]; }
-    if 11 < N { bytes[11] = input[11]; }
-    if 12 < N { bytes[12] = input[12]; }
-    if 13 < N { bytes[13] = input[13]; }
-    if 14 < N { bytes[14] = input[14]; }
-
-    TagStr {
-        bytes,
-        len: N as u8,
-    }
-}
-
-impl ElDefinition {
-    const fn new<const N: usize>(name: &'static [u8; N], closing: ClosingRules) -> Self {
-        ElDefinition {
-            name: tagstr(name),
-            closing,
-        }
-    }
-}
-
-use ClosingRules::*;
-
-enum_map! {
-    pub static ELS: [ElDefinition] for El {
-        Anchor => (b"a", Required),
-        Abbr => (b"abbr", Required),
-        Address => (b"address", Required),
-        Area => (b"area", Void),
-        Article => (b"article", Required),
-        Aside => (b"aside", Required),
-        Audio => (b"audio", Required),
-        Bold => (b"b", Required),
-        Base => (b"base", Void),
-        Bdi => (b"bdi", Required),
-        Bdo => (b"bdo", Required),
-        Blockquote => (b"blockquote", Required),
-        Body => (b"body", Optional(&[])),
-        Br => (b"br", Void),
-        Button => (b"button", Required),
-        Canvas => (b"canvas", Required),
-        Caption => (b"caption", Optional(&[])),
-        Cite => (b"cite", Required),
-        Code => (b"code", Required),
-        Col => (b"col", Void),
-        ColGroup => (b"colgroup", Optional(&[])),
-        Data => (b"data", Required),
-        DataList => (b"datalist", Required),
-        Dd => (b"dd", Optional(&[El::Dd, El::Dt])),
-        Del => (b"del", Required),
-        Definition => (b"dfn", Required),
-        Details => (b"details", Required),
-        Dialog => (b"dialog", Required),
-        Div => (b"div", Required),
-        Dl => (b"dl", Required),
-        Dt => (b"dt", Optional(&[El::Dd, El::Dt])),
-        Em => (b"em", Required),
-        Embed => (b"embed", Void),
-        FieldSet => (b"fieldset", Required),
-        FigCaption => (b"figcaption", Required),
-        Figure => (b"figure", Required),
-        Footer => (b"footer", Required),
-        Form => (b"form", Required),
-        Head => (b"head", Optional(&[])),
-        Header => (b"header", Required),
-        Header1 => (b"h1", Required),
-        Header2 => (b"h1", Required),
-        Header3 => (b"h1", Required),
-        Header4 => (b"h1", Required),
-        Header5 => (b"h1", Required),
-        Header6 => (b"h1", Required),
-        HGroup => (b"hgroup", Required),
-        Hr => (b"hr", Void),
-        Html => (b"html", Optional(&[])),
-        Italic => (b"i", Required),
-        IFrame => (b"iframe", Required),
-        Img => (b"img", Void),
-        Input => (b"input", Void),
-        Ins => (b"ins", Required),
-        Kbd => (b"kbd", Required),
-        Label => (b"label", Required),
-        Legend => (b"legend", Required),
-        Li => (b"li", Optional(&[El::Li])),
-        Link => (b"link", Void),
-        Main => (b"main", Required),
-        Map => (b"map", Required),
-        Mark => (b"mark", Required),
-        Menu => (b"menu", Required),
-        Meta => (b"meta", Void),
-        Meter => (b"meter", Required),
-        Nav => (b"nav", Required),
-        NoScript => (b"noscript", Required),
-        Object => (b"object", Required),
-        Ol => (b"ol", Required),
-        OptGroup => (b"optgroup", Optional(&[El::OptGroup])),
-        Option => (b"option", Optional(&[El::Option, El::OptGroup])),
-        Output => (b"output", Required),
-        Paragraph => (b"p", Optional(&[El::Paragraph])),
-        Picture => (b"picture", Required),
-        Pre => (b"pre", Required),
-        Progress => (b"progress", Required),
-        Quote => (b"q", Required),
-        Rp => (b"rp", Optional(&[El::Rp, El::Rt])),
-        Rt => (b"rt", Optional(&[El::Rp, El::Rt])),
-        Ruby => (b"ruby", Required),
-        Strike => (b"s", Required),
-        Samp => (b"samp", Required),
-        Script => (b"script", Required),
-        Section => (b"section", Required),
-        Select => (b"select", Required),
-        Slot => (b"slot", Required),
-        Small => (b"small", Required),
-        Source => (b"source", Void),
-        Span => (b"span", Required),
-        Strong => (b"strong", Required),
-        Style => (b"style", Required),
-        Sub => (b"sub", Required),
-        Summary => (b"summary", Required),
-        Sup => (b"sup", Required),
-        Table => (b"table", Required),
-        Tbody => (b"tbody", Optional(&[El::Tbody, El::Tfoot])),
-        Td => (b"td", Optional(&[El::Td, El::Th])),
-        Template => (b"template", Required),
-        TextArea => (b"textarea", Required),
-        Tfoot => (b"tfoot", Optional(&[])),
-        Th => (b"th", Optional(&[El::Td, El::Th])),
-        Thead => (b"thead", Optional(&[El::Tbody, El::Tfoot])),
-        Time => (b"time", Required),
-        Title => (b"title", Required),
-        Tr => (b"tr", Optional(&[El::Tr])),
-        Track => (b"track", Required),
-        Underline => (b"u", Required),
-        Ul => (b"ul", Required),
-        Var => (b"var", Required),
-        Video => (b"video", Required),
-        Wbr => (b"wbr", Void),
-    }
+build_tags! {
+    Anchor      "a"             _
+    Abbr        "abbr"          _
+    Address     "address"       _
+    Area        "area"          /
+    Article     "article"       _
+    Aside       "aside"         _
+    Audio       "audio"         _
+    Bold        "b"             _
+    Base        "base"          /
+    Bdi         "bdi"           _
+    Bdo         "bdo"           _
+    Blockquote  "blockquote"    _
+    Body        "body"          []
+    Br          "br"            /
+    Button      "button"        _
+    Canvas      "canvas"        _
+    Caption     "caption"       []
+    Cite        "cite"          _
+    Code        "code"          _
+    Col         "col"           /
+    ColGroup    "colgroup"      []
+    Data        "data"          _
+    DataList    "datalist"      _
+    Dd          "dd"            [Dd Dt]
+    Del         "del"           _
+    Definition  "dfn"           _
+    Details     "details"       _
+    Dialog      "dialog"        _
+    Div         "div"           _
+    Dl          "dl"             _
+    Dt          "dt"            [Dd Dt]
+    Em          "em"            _
+    Embed       "embed"         /
+    FieldSet    "fieldset"      _
+    FigCaption  "figcaption"    _
+    Figure      "figure"        _
+    Footer      "footer"        _
+    Form        "form"          _
+    Head        "head"          []
+    Header      "header"        _
+    Header1     "h1"            _
+    Header2     "h2"            _
+    Header3     "h3"            _
+    Header4     "h4"            _
+    Header5     "h5"            _
+    Header6     "h6"            _
+    HGroup      "hgroup"        _
+    Hr          "hr"            /
+    Html        "html"          []
+    Italic      "i"             _
+    IFrame      "iframe"        _
+    Img         "img"           /
+    Input       "input"         /
+    Ins         "ins"           _
+    Kbd         "kbd"           _
+    Label       "label"         _
+    Legend      "legend"        _
+    Li          "li"            [Li]
+    Link        "link"          /
+    Main        "main"          _
+    Map         "map"           _
+    Mark        "mark"          _
+    Menu        "menu"          _
+    Meta        "meta"          /
+    Meter       "meter"         _
+    Nav         "nav"           _
+    NoScript    "noscript"      _
+    Object      "object"        _
+    Ol          "ol"            _
+    OptGroup    "optgroup"      [OptGroup]
+    Option      "option"        [Option OptGroup]
+    Output      "output"        _
+    Paragraph   "p"             [
+                                    Paragraph Address Article Aside Blockquote Details Div
+                                    Dl FieldSet FigCaption Figure Footer Form Header
+                                    Header1 Header2 Header3 Header4 Header5 Header6 HGroup
+                                    Hr Main Menu Nav Ol Pre Search Section Table Ul
+                                ]
+    Picture     "picture"       _
+    Pre         "pre"           _
+    Progress    "progress"      _
+    Quote       "q"             _
+    Rp          "rp"            [Rp Rt]
+    Rt          "rt"            [Rp Rt]
+    Ruby        "ruby"          _
+    Strike      "s"             _
+    Samp        "samp"          _
+    Search      "search"        _
+    Script      "script"        _
+    Section     "section"       _
+    Select      "select"        _
+    Slot        "slot"          _
+    Small       "small"         _
+    Source      "source"        /
+    Span        "span"          _
+    Strong      "strong"        _
+    Style       "style"         _
+    Sub         "su"            _
+    Summary     "summary"       _
+    Sup         "sup"           _
+    Table       "table"         _
+    Tbody       "tbody"         [Tbody Tfoot]
+    Td          "td"            [Td Th]
+    Template    "template"      _
+    TextArea    "textarea"      _
+    Tfoot       "tfoot"         []
+    Th          "th"            [Td Th]
+    Thead       "thead"         [Tbody Tfoot]
+    Time        "time"          _
+    Title       "title"         _
+    Tr          "tr"            [Tr]
+    Track       "track"         /
+    Underline   "u"             _
+    Ul          "ul"            _
+    Var         "var"           _
+    Video       "video"         _
+    Wbr         "wbr"           /
 }

--- a/crates/kobold_macros/src/dom/shallow.rs
+++ b/crates/kobold_macros/src/dom/shallow.rs
@@ -179,9 +179,23 @@ pub struct Tag {
     pub content: TokenStream,
 }
 
+pub enum IsClosing {
+    No,
+    Implicit,
+    Explicit,
+}
+
 impl Tag {
-    pub fn is_closing(&self, opening: &TagName) -> bool {
-        self.nesting == TagNesting::Closing && &self.name == opening
+    pub fn is_closing(&self, opening: &TagName) -> IsClosing {
+        if self.nesting == TagNesting::Closing {
+            if &self.name == opening {
+                IsClosing::Explicit
+            } else {
+                IsClosing::Implicit
+            }
+        } else {
+            IsClosing::No
+        }
     }
 }
 

--- a/crates/kobold_macros/src/dom/shallow.rs
+++ b/crates/kobold_macros/src/dom/shallow.rs
@@ -188,14 +188,22 @@ pub enum IsClosing {
 impl Tag {
     pub fn is_closing(&self, opening: &TagName) -> IsClosing {
         if self.nesting == TagNesting::Closing {
-            if &self.name == opening {
+            return if &self.name == opening {
                 IsClosing::Explicit
             } else {
                 IsClosing::Implicit
-            }
-        } else {
-            IsClosing::No
+            };
         }
+
+        if let (TagName::HtmlElement { name, .. }, TagName::HtmlElement { name: opening, .. }) =
+            (&self.name, opening)
+        {
+            if opening.closes_on(*name) {
+                return IsClosing::Implicit;
+            }
+        }
+
+        IsClosing::No
     }
 }
 

--- a/crates/kobold_macros/src/gen.rs
+++ b/crates/kobold_macros/src/gen.rs
@@ -93,9 +93,9 @@ impl Generator {
                 hoisted: _,
             }) => {
                 let body = if code.is_empty() {
-                    format!("return document.createElement(\"{tag}\");\n")
+                    format!("return document.createElement(\"{tag:?}\");\n")
                 } else {
-                    format!("let {var}=document.createElement(\"{tag}\");\n{code}return {var};\n")
+                    format!("let {var}=document.createElement(\"{tag:?}\");\n{code}return {var};\n")
                 };
 
                 (var, body, args, Anchor::Element(typ))

--- a/crates/kobold_macros/src/gen/element.rs
+++ b/crates/kobold_macros/src/gen/element.rs
@@ -6,7 +6,7 @@ use std::fmt::{Arguments, Write};
 
 use proc_macro::{Literal, TokenStream};
 
-use crate::dom::{Attribute, AttributeValue, CssValue, HtmlElement, ElementTag};
+use crate::dom::{Attribute, AttributeValue, CssValue, ElementTag, HtmlElement};
 use crate::gen::{append, DomNode, Generator, IntoGenerator, JsArgument, Short};
 use crate::itertools::IteratorExt;
 use crate::parse::IdentExt;

--- a/crates/kobold_macros/src/gen/element.rs
+++ b/crates/kobold_macros/src/gen/element.rs
@@ -6,7 +6,7 @@ use std::fmt::{Arguments, Write};
 
 use proc_macro::{Literal, TokenStream};
 
-use crate::dom::{Attribute, AttributeValue, CssValue, HtmlElement};
+use crate::dom::{Attribute, AttributeValue, CssValue, HtmlElement, ElementTag};
 use crate::gen::{append, DomNode, Generator, IntoGenerator, JsArgument, Short};
 use crate::itertools::IteratorExt;
 use crate::parse::IdentExt;
@@ -14,7 +14,7 @@ use crate::tokenize::prelude::*;
 
 pub struct JsElement {
     /// Tag name of the element such as `div`
-    pub tag: String,
+    pub tag: ElementTag,
 
     /// The `web-sys` type of this element, such as `HtmlElement`, spanned to tag invocation.
     pub typ: &'static str,

--- a/crates/kobold_macros/src/gen/fragment.rs
+++ b/crates/kobold_macros/src/gen/fragment.rs
@@ -64,7 +64,7 @@ pub fn append(
 
                     args.push(JsArgument::new(var));
                 } else {
-                    let _ = writeln!(js, "let {}=document.createElement(\"{}\");", el.var, el.tag);
+                    let _ = writeln!(js, "let {}=document.createElement(\"{}\");", el.var, &*el.tag);
 
                     js.push_str(&el.code);
 

--- a/crates/kobold_macros/src/gen/fragment.rs
+++ b/crates/kobold_macros/src/gen/fragment.rs
@@ -64,7 +64,11 @@ pub fn append(
 
                     args.push(JsArgument::new(var));
                 } else {
-                    let _ = writeln!(js, "let {}=document.createElement(\"{}\");", el.var, &*el.tag);
+                    let _ = writeln!(
+                        js,
+                        "let {}=document.createElement(\"{}\");",
+                        el.var, &*el.tag
+                    );
 
                     js.push_str(&el.code);
 

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -15,7 +15,6 @@ fn Counter() -> impl View {
                 // `{onclick}` here is shorthand for `onclick={onclick}`
                 <button {onclick}>"Click me!"</button>
                 <button onclick={reset}>"Reset"</button>
-            </p>
         }
     })
 }
@@ -28,7 +27,7 @@ fn ShowCount(count: u32) -> impl View {
         n => view! { { n }" times." },
     };
 
-    view! { <h3>"You've clicked the button "{ count }</h3> }
+    view! { <h3> "You've clicked the button "{ count } }
 }
 
 fn main() {

--- a/examples/csv_editor/src/main.rs
+++ b/examples/csv_editor/src/main.rs
@@ -52,8 +52,6 @@ fn Editor() -> impl View {
                     {
                         for state.columns().map(|col| view! { <Head {col} {state} /> })
                     }
-                    </tr>
-                </thead>
                 <tbody>
                 {
                     for state.rows().map(move |row| view! {
@@ -96,15 +94,30 @@ fn Cell(col: usize, row: usize, state: &Hook<State>) -> impl View + '_ {
     let value = state.source.get_text(&state.rows[row][col]);
 
     if state.editing == (Editing::Cell { row, col }) {
-        let onchange = state.bind(move |state, e: Event<Input>| {
-            state.rows[row][col] = Text::Owned(e.target().value().into());
-            state.editing = Editing::None;
-        });
+        bind! {
+            state:
+
+            let onchange = move |e: Event<Input>| {
+                state.rows[row][col] = Text::Owned(e.target().value().into());
+                state.editing = Editing::None;
+            };
+        }
+
+        let mut selected = false;
+
+        let onmouseenter = move |e: MouseEvent<Input>| {
+            if !selected {
+                let input = e.target();
+                input.focus();
+                input.select();
+                selected = true;
+            }
+        };
 
         view! {
             <td.edit>
                 { ref value }
-                <input.edit {onchange} value={ ref value }>
+                <input.edit {onchange} {onmouseenter} value={ ref value }>
         }
     } else {
         let ondblclick = state.bind(move |s, _| s.editing = Editing::Cell { row, col });

--- a/examples/csv_editor/src/main.rs
+++ b/examples/csv_editor/src/main.rs
@@ -44,7 +44,7 @@ fn Editor() -> impl View {
         }
 
         view! {
-            <input type="file" accept="text/csv" onchange={onload} />
+            <input type="file" accept="text/csv" onchange={onload}>
             <h1>{ ref state.name }</h1>
             <table {onkeydown}>
                 <thead>
@@ -63,11 +63,8 @@ fn Editor() -> impl View {
                                 <Cell {col} {row} {state} />
                             })
                         }
-                        </tr>
                     })
                 }
-                </tbody>
-            </table>
         }
     })
 }
@@ -85,13 +82,12 @@ fn Head(col: usize, state: &Hook<State>) -> impl View + '_ {
         view! {
             <th.edit>
                 { ref value }
-                <input.edit.edit-head {onchange} value={ ref value } />
-            </th>
+                <input.edit.edit-head {onchange} value={ ref value }>
         }
     } else {
         let ondblclick = state.bind(move |s, _| s.editing = Editing::Column { col });
 
-        view! { <th {ondblclick}>{ ref value }</th> }
+        view! { <th {ondblclick}>{ ref value } }
     }
 }
 
@@ -108,13 +104,12 @@ fn Cell(col: usize, row: usize, state: &Hook<State>) -> impl View + '_ {
         view! {
             <td.edit>
                 { ref value }
-                <input.edit {onchange} value={ ref value } />
-            </td>
+                <input.edit {onchange} value={ ref value }>
         }
     } else {
         let ondblclick = state.bind(move |s, _| s.editing = Editing::Cell { row, col });
 
-        view! { <td {ondblclick}>{ ref value }</td> }
+        view! { <td {ondblclick}>{ ref value } }
     }
 }
 

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -2,10 +2,8 @@ use kobold::prelude::*;
 
 #[component]
 fn Hello(name: &str) -> impl View + '_ {
-    view! {
-        // No need to close tags at the end of the macro
-        <h1> "Hello "{ name }"!"
-    }
+    // No need to close tags at the end of the macro
+    view! { <h1> "Hello "{ name }"!" }
 }
 
 fn main() {

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -3,7 +3,8 @@ use kobold::prelude::*;
 #[component]
 fn Hello(name: &str) -> impl View + '_ {
     view! {
-        <h1>"Hello "{ name }"!"</h1>
+        // No need to close tags at the end of the macro
+        <h1> "Hello "{ name }"!"
     }
 }
 

--- a/examples/interval/src/main.rs
+++ b/examples/interval/src/main.rs
@@ -13,7 +13,6 @@ fn Elapsed() -> impl View {
                 "Elapsed seconds: "{ seconds }" "
                 // `{onclick}` here is shorthand for `onclick={onclick}`
                 <button {onclick}>"Reset"</button>
-            </p>
         }
     })
     .once(|hook| {

--- a/examples/list/src/main.rs
+++ b/examples/list/src/main.rs
@@ -27,8 +27,6 @@ fn ListExample(count: u32) -> impl View {
                     // `{n}` is just shorthand for `n={n}`.
                     for (1..=count.get()).map(|n| view! { <ListItem {n} /> })
                 }
-                </ul>
-            </div>
         }
     })
 }

--- a/examples/stateful/src/main.rs
+++ b/examples/stateful/src/main.rs
@@ -43,7 +43,6 @@ fn App() -> impl View {
                 " "
                 <button onclick={adult}>"18"</button>
                 <button onclick={inc_age}>"+"</button>
-            </div>
         }
     })
 }

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -34,7 +34,6 @@ fn App() -> impl View {
                                     .filtered_entries()
                                     .map(move |(idx, entry)| view! { <EntryView {idx} {entry} {state} /> })
                             }
-                        </ul>
                     </section>
                     <footer.footer.{hidden}>
                         <span.todo-count>
@@ -53,8 +52,6 @@ fn App() -> impl View {
                         </ul>
                         <button.clear-completed.{completed_hidden} onclick={clear}>
                             "Clear completed"
-                        </button>
-                    </footer>
                 </section>
                 <footer.info>
                     <p>"Double-click to edit a todo"</p>

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -20,15 +20,15 @@ fn App() -> impl View {
         }
 
         view! {
-            <div .todomvc-wrapper>
-                <section .todoapp>
-                    <header .header>
+            <div.todomvc-wrapper>
+                <section.todoapp>
+                    <header.header>
                         <h1>"todos"</h1>
                         <EntryInput {state} />
                     </header>
                     <section .main.{hidden}>
                         <ToggleAll {active_count} {state} />
-                        <ul .todo-list>
+                        <ul.todo-list>
                             {
                                 for state
                                     .filtered_entries()
@@ -36,8 +36,8 @@ fn App() -> impl View {
                             }
                         </ul>
                     </section>
-                    <footer .footer.{hidden}>
-                        <span .todo-count>
+                    <footer.footer.{hidden}>
+                        <span.todo-count>
                             <strong>{ active_count }</strong>
                             {
                                 ref match active_count {
@@ -46,7 +46,7 @@ fn App() -> impl View {
                                 }
                             }
                         </span>
-                        <ul .filters>
+                        <ul.filters>
                             <FilterView filter={Filter::All} {state} />
                             <FilterView filter={Filter::Active} {state} />
                             <FilterView filter={Filter::Completed} {state} />
@@ -56,7 +56,7 @@ fn App() -> impl View {
                         </button>
                     </footer>
                 </section>
-                <footer .info>
+                <footer.info>
                     <p>"Double-click to edit a todo"</p>
                     <p>"Written by "<a href="https://maciej.codes/" target="_blank">"Maciej Hirsz"</a></p>
                     <p>"Part of "<a href="http://todomvc.com/" target="_blank">"TodoMVC"</a></p>
@@ -81,7 +81,7 @@ fn EntryInput(state: &Hook<State>) -> impl View + '_ {
     }
 
     view! {
-        <input.new-todo placeholder="What needs to be done?" {onchange} />
+        <input.new-todo placeholder="What needs to be done?" {onchange}>
     }
 }
 
@@ -92,7 +92,7 @@ fn ToggleAll(active_count: usize, state: &Hook<State>) -> impl View + '_ {
     }
 
     view! {
-        <input #toggle-all.toggle-all type="checkbox" checked={active_count == 0} {onclick} />
+        <input #toggle-all.toggle-all type="checkbox" checked={active_count == 0} {onclick}>
         <label for="toggle-all" />
     }
 }
@@ -123,7 +123,7 @@ pub fn EntryView<'a>(idx: usize, entry: &'a Entry, state: &'a Hook<State>) -> im
                 onmouseover={|event| event.target().focus()}
                 {onkeypress}
                 {onblur}
-            />
+            >
         }
     });
 
@@ -138,13 +138,13 @@ pub fn EntryView<'a>(idx: usize, entry: &'a Entry, state: &'a Hook<State>) -> im
     let completed = class!("completed" if entry.completed);
 
     view! {
-        <li .todo.{editing}.{completed}>
-            <div .view>
-                <input .toggle type="checkbox" checked={entry.completed} {onchange} />
+        <li.todo.{editing}.{completed}>
+            <div.view>
+                <input .toggle type="checkbox" checked={entry.completed} {onchange}>
                 <label ondblclick={edit} >
                     { ref entry.description }
                 </label>
-                <button .destroy onclick={remove} />
+                <button.destroy onclick={remove} />
             </div>
             { input }
         </li>

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -51,7 +51,7 @@ fn App() -> impl View {
                             <FilterView filter={Filter::Active} {state} />
                             <FilterView filter={Filter::Completed} {state} />
                         </ul>
-                        <button .clear-completed.{completed_hidden} onclick={clear}>
+                        <button.clear-completed.{completed_hidden} onclick={clear}>
                             "Clear completed"
                         </button>
                     </footer>
@@ -60,8 +60,6 @@ fn App() -> impl View {
                     <p>"Double-click to edit a todo"</p>
                     <p>"Written by "<a href="https://maciej.codes/" target="_blank">"Maciej Hirsz"</a></p>
                     <p>"Part of "<a href="http://todomvc.com/" target="_blank">"TodoMVC"</a></p>
-                </footer>
-            </div>
         }
     })
 }
@@ -147,7 +145,6 @@ pub fn EntryView<'a>(idx: usize, entry: &'a Entry, state: &'a Hook<State>) -> im
                 <button.destroy onclick={remove} />
             </div>
             { input }
-        </li>
     }
 }
 
@@ -161,11 +158,7 @@ fn FilterView(filter: Filter, state: &Hook<State>) -> impl View + '_ {
     }
 
     view! {
-        <li>
-            <a {class} {onclick} href={static filter.href()}>
-                { static filter.label() }
-            </a>
-        </li>
+        <li><a {class} {onclick} href={static filter.href()}> { static filter.label() }
     }
 }
 

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -50,13 +50,12 @@ fn App() -> impl View {
                             <FilterView filter={Filter::Active} {state} />
                             <FilterView filter={Filter::Completed} {state} />
                         </ul>
-                        <button.clear-completed.{completed_hidden} onclick={clear}>
-                            "Clear completed"
+                        <button.clear-completed.{completed_hidden} onclick={clear}> "Clear completed"
                 </section>
                 <footer.info>
-                    <p>"Double-click to edit a todo"</p>
-                    <p>"Written by "<a href="https://maciej.codes/" target="_blank">"Maciej Hirsz"</a></p>
-                    <p>"Part of "<a href="http://todomvc.com/" target="_blank">"TodoMVC"</a></p>
+                    <p> "Double-click to edit a todo"
+                    <p> "Written by "<a href="https://maciej.codes/" target="_blank">"Maciej Hirsz"</a>
+                    <p> "Part of "<a href="http://todomvc.com/" target="_blank">"TodoMVC"</a>
         }
     })
 }
@@ -112,7 +111,7 @@ pub fn EntryView<'a>(idx: usize, entry: &'a Entry, state: &'a Hook<State>) -> im
         }
 
         view! {
-            <input .edit
+            <input.edit
                 type="text"
                 value={static &entry.description}
                 onmouseover={|event| event.target().focus()}
@@ -135,7 +134,7 @@ pub fn EntryView<'a>(idx: usize, entry: &'a Entry, state: &'a Hook<State>) -> im
     view! {
         <li.todo.{editing}.{completed}>
             <div.view>
-                <input .toggle type="checkbox" checked={entry.completed} {onchange}>
+                <input.toggle type="checkbox" checked={entry.completed} {onchange}>
                 <label ondblclick={edit} >
                     { ref entry.description }
                 </label>


### PR DESCRIPTION
This implements the proposal from #50 with some alterations:

# All closing tags for HTML elements are optional

End of macro closes all tags:

```rust
view! {
    // no closing tags necessary at the end of macro
    <header><h1> "Hello Kobold"
}
```

Closing an ancestor closes all children:

```rust
view! {
    <div>
        <header>
            <h1> "Hello Kobold"
    // Closing the `div` closes both `h1` and `header`
    </div>
}
```

:warning: **Note:** components still need to be closed:

```rust
view! {
    // trailing `/` is mandatory for components without children
    <MyComponent />
    <p> "Paragraph under the component"
}
```

# [_Void elements_](https://html.spec.whatwg.org/#void-elements) don't need to be closed

```rust
view! {
    <div>
        "This text is inside the div"
        // `input` is forbidden from having children and doesn't need closing
        <input type="text">
        "This text is also inside the div"
}
```

# Some tags are implicitly closed by other tags

This follows all the HTML5 rules, making the following legal syntax:

```rust
view! {
    <ul.my-list>
        // `li` closes previous `li`
        <li> "Item 1"
        <li> "Item 2"
        <li> "Item 3"
}
```

```rust
view! {
    <table.some-class>
        <tr>
            // `td` closes previous `td` or `th`
            <td> "Row 1, Col 1"
            <td> "Row 1, Col 2"
            <td> "Row 1, Col 3"
        // `tr` closes previous `td`, `th`, and/or `tr`
        <tr>
            <td> "Row 2, Col 1"
            <td> "Row 2, Col 2"
            <td> "Row 2, Col 3"
} 
```