### PR TITLE
Safety

### DIFF
--- a/crates/kobold/src/event.rs
+++ b/crates/kobold/src/event.rs
@@ -39,7 +39,7 @@ macro_rules! event {
                 }
             }
 
-            impl<T> hidden::EventCast for $event<T> {}
+            impl<T> EventCast for $event<T> {}
 
             impl<T> Deref for $event<T> {
                 type Target = web_sys::$event;
@@ -65,13 +65,13 @@ macro_rules! event {
     };
 }
 
-mod hidden {
+mod sealed {
     pub trait EventCast {}
 
     impl EventCast for web_sys::Event {}
 }
 
-pub(crate) use hidden::EventCast;
+pub(crate) use sealed::EventCast;
 
 event! {
     /// [`web_sys::Event`](web_sys::Event)

--- a/crates/kobold/src/event.rs
+++ b/crates/kobold/src/event.rs
@@ -98,7 +98,7 @@ where
     E: EventCast,
 {
     fn build(self) -> ListenerProduct<Self> {
-        let raw = Box::into_raw(Box::new(self));
+        let raw = Box::leak(Box::new(self));
 
         let js = Closure::wrap(unsafe {
             Box::from_raw(raw as *mut dyn FnMut(E) as *mut dyn FnMut(web_sys::Event))

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -338,7 +338,7 @@ pub trait View {
         Self: Sized,
     {
         OnMount {
-            html: self,
+            view: self,
             handler,
         }
     }
@@ -351,26 +351,26 @@ pub trait View {
         Self: Sized,
     {
         OnRender {
-            html: self,
+            view: self,
             handler,
         }
     }
 }
 
-pub struct OnMount<H, F> {
-    html: H,
+pub struct OnMount<V, F> {
+    view: V,
     handler: F,
 }
 
-impl<H, F> View for OnMount<H, F>
+impl<V, F> View for OnMount<V, F>
 where
-    H: View,
-    F: FnOnce(&<H::Product as Mountable>::Js),
+    V: View,
+    F: FnOnce(&<V::Product as Mountable>::Js),
 {
-    type Product = H::Product;
+    type Product = V::Product;
 
     fn build(self) -> Self::Product {
-        let prod = self.html.build();
+        let prod = self.view.build();
 
         (self.handler)(prod.js().unchecked_ref());
 
@@ -378,24 +378,24 @@ where
     }
 
     fn update(self, p: &mut Self::Product) {
-        self.html.update(p);
+        self.view.update(p);
     }
 }
 
-pub struct OnRender<H, F> {
-    html: H,
+pub struct OnRender<V, F> {
+    view: V,
     handler: F,
 }
 
-impl<H, F> View for OnRender<H, F>
+impl<V, F> View for OnRender<V, F>
 where
-    H: View,
-    F: FnOnce(&<H::Product as Mountable>::Js),
+    V: View,
+    F: FnOnce(&<V::Product as Mountable>::Js),
 {
-    type Product = H::Product;
+    type Product = V::Product;
 
     fn build(self) -> Self::Product {
-        let prod = self.html.build();
+        let prod = self.view.build();
 
         (self.handler)(prod.js().unchecked_ref());
 
@@ -403,19 +403,19 @@ where
     }
 
     fn update(self, p: &mut Self::Product) {
-        self.html.update(p);
+        self.view.update(p);
 
         (self.handler)(p.js().unchecked_ref());
     }
 }
 
 /// Start the Kobold app by mounting given [`View`](View) in the document `body`.
-pub fn start(html: impl View) {
+pub fn start(view: impl View) {
     init_panic_hook();
 
     use std::mem::ManuallyDrop;
 
-    let product = ManuallyDrop::new(html.build());
+    let product = ManuallyDrop::new(view.build());
 
     internal::append_body(product.js());
 }

--- a/crates/kobold/src/list.rs
+++ b/crates/kobold/src/list.rs
@@ -92,8 +92,8 @@ where
     }
 }
 
-impl<H: View> View for Vec<H> {
-    type Product = ListProduct<H::Product>;
+impl<V: View> View for Vec<V> {
+    type Product = ListProduct<V::Product>;
 
     fn build(self) -> Self::Product {
         List(self).build()
@@ -104,11 +104,11 @@ impl<H: View> View for Vec<H> {
     }
 }
 
-impl<'a, H> View for &'a [H]
+impl<'a, V> View for &'a [V]
 where
-    &'a H: View,
+    &'a V: View,
 {
-    type Product = ListProduct<<&'a H as View>::Product>;
+    type Product = ListProduct<<&'a V as View>::Product>;
 
     fn build(self) -> Self::Product {
         List(self).build()
@@ -119,8 +119,8 @@ where
     }
 }
 
-impl<H: View, const N: usize> View for [H; N] {
-    type Product = ListProduct<H::Product>;
+impl<V: View, const N: usize> View for [V; N] {
+    type Product = ListProduct<V::Product>;
 
     fn build(self) -> Self::Product {
         List(self).build()

--- a/crates/kobold/src/stateful.rs
+++ b/crates/kobold/src/stateful.rs
@@ -109,7 +109,6 @@ where
     Stateful { state, render }
 }
 
-
 impl<S, F, V> View for Stateful<S, F>
 where
     S: IntoState,

--- a/crates/kobold/src/stateful.rs
+++ b/crates/kobold/src/stateful.rs
@@ -91,14 +91,14 @@ pub struct StatefulProduct<S> {
 /// // ...or a function with no parameters
 /// let vec_view = stateful(Vec::new, |counts: &Hook<Vec<i32>>| { "TODO" });
 /// ```
-pub fn stateful<'a, S, F, H>(
+pub fn stateful<'a, S, F, V>(
     state: S,
     render: F,
-) -> Stateful<S, impl Fn(*const Hook<S::State>) -> H + 'static>
+) -> Stateful<S, impl Fn(*const Hook<S::State>) -> V + 'static>
 where
     S: IntoState,
-    F: Fn(&'a Hook<S::State>) -> H + 'static,
-    H: View + 'a,
+    F: Fn(&'a Hook<S::State>) -> V + 'static,
+    V: View + 'a,
 {
     // There is no safe way to represent a generic closure with generic return type
     // that borrows from that closure's arguments, without also slapping a lifetime.
@@ -108,6 +108,7 @@ where
     let render = move |hook: *const Hook<S::State>| render(unsafe { &*hook });
     Stateful { state, render }
 }
+
 
 impl<S, F, V> View for Stateful<S, F>
 where

--- a/crates/kobold/src/stateful/cell.rs
+++ b/crates/kobold/src/stateful/cell.rs
@@ -22,7 +22,7 @@ impl<T> WithCell<T> {
         F: FnOnce(&mut T),
     {
         if self.borrowed.get() {
-            return;
+            wasm_bindgen::throw_str("Cyclic state borrowing");
         }
 
         self.borrowed.set(true);
@@ -30,7 +30,15 @@ impl<T> WithCell<T> {
         self.borrowed.set(false);
     }
 
-    pub unsafe fn borrow_unchecked(&self) -> &T {
+    pub unsafe fn ref_unchecked(&self) -> &T {
+        debug_assert_eq!(self.borrowed.get(), false);
+
         &*self.data.get()
+    }
+
+    pub unsafe fn mut_unchecked(&self) -> &mut T {
+        debug_assert_eq!(self.borrowed.get(), false);
+
+        &mut *self.data.get()
     }
 }


### PR DESCRIPTION
Added a bunch of comments on safety for unsafe code in the `stateful` module.

In addition:

1. Interacting with `Signal` will now throw an exception multiple mutations occur at once (as opposed to silently failing as before).
2. Synchronous event callbacks can now safely borrow state without checks after changes done in #63.
3. Fixed some old generics referencing `H` for `Html` before the trait was renamed to `View`.