### PR TITLE
Fix errors in nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Run tests
+      - name: Formatting
         run: cargo fmt --check
 
-  tests:
+  check:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Formatting
+        run: cargo check
+
+  tests:
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+        os:
+          - ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Run tests

--- a/crates/kobold_macros/src/branching/ast.rs
+++ b/crates/kobold_macros/src/branching/ast.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 use std::fmt::{self, Debug};
 use std::rc::Rc;
 
-use proc_macro::{Delimiter, Span, TokenStream, TokenTree};
+use tokens::{Delimiter, Span, TokenStream, TokenTree};
 
 #[derive(Default, Debug)]
 pub struct Scope {

--- a/crates/kobold_macros/src/branching/parse.rs
+++ b/crates/kobold_macros/src/branching/parse.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use arrayvec::ArrayVec;
-use proc_macro::{Group, TokenStream, TokenTree};
+use tokens::{Group, TokenStream, TokenTree};
 
 use crate::parse::prelude::*;
 use crate::tokenize::TokenStreamExt;

--- a/crates/kobold_macros/src/branching/tokenize.rs
+++ b/crates/kobold_macros/src/branching/tokenize.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use proc_macro::{Group, TokenStream, TokenTree};
+use tokens::{Group, TokenStream, TokenTree};
 
 use crate::tokenize::prelude::*;
 

--- a/crates/kobold_macros/src/dom.rs
+++ b/crates/kobold_macros/src/dom.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use proc_macro::{Delimiter, Ident, Literal, Spacing, Span, TokenStream, TokenTree};
+use tokens::{Delimiter, Ident, Literal, Spacing, Span, TokenStream, TokenTree};
 
 use crate::parse::prelude::*;
 use crate::syntax::CssLabel;

--- a/crates/kobold_macros/src/dom/expression.rs
+++ b/crates/kobold_macros/src/dom/expression.rs
@@ -4,7 +4,7 @@
 
 use std::fmt::{self, Debug};
 
-use proc_macro::{Group, Ident, Span, TokenStream, TokenTree};
+use tokens::{Group, Ident, Span, TokenStream, TokenTree};
 
 use crate::dom::Node;
 use crate::parse::IdentExt;

--- a/crates/kobold_macros/src/dom/shallow.rs
+++ b/crates/kobold_macros/src/dom/shallow.rs
@@ -9,7 +9,7 @@
 
 use std::fmt::{self, Display, Write};
 
-use proc_macro::{Group, Ident, Literal, Spacing, Span, TokenStream, TokenTree};
+use tokens::{Group, Ident, Literal, Spacing, Span, TokenStream, TokenTree};
 
 use crate::dom::ElementTag;
 use crate::parse::prelude::*;

--- a/crates/kobold_macros/src/fn_component.rs
+++ b/crates/kobold_macros/src/fn_component.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use proc_macro::{Ident, TokenStream, TokenTree};
+use tokens::{Ident, TokenStream, TokenTree};
 
 use crate::parse::prelude::*;
 use crate::tokenize::prelude::*;

--- a/crates/kobold_macros/src/gen.rs
+++ b/crates/kobold_macros/src/gen.rs
@@ -6,7 +6,7 @@ use std::fmt::{Debug, Write};
 use std::hash::Hash;
 
 use arrayvec::ArrayString;
-use proc_macro::{Ident, TokenStream};
+use tokens::{Ident, TokenStream};
 
 use crate::dom::{Expression, Node};
 use crate::itertools::IteratorExt;

--- a/crates/kobold_macros/src/gen/component.rs
+++ b/crates/kobold_macros/src/gen/component.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use proc_macro::TokenStream;
+use tokens::TokenStream;
 
 use crate::dom::{Component, Property};
 use crate::gen::{DomNode, Field, Generator, IntoGenerator, TokenStreamExt};

--- a/crates/kobold_macros/src/gen/element.rs
+++ b/crates/kobold_macros/src/gen/element.rs
@@ -4,7 +4,7 @@
 
 use std::fmt::{Arguments, Write};
 
-use proc_macro::{Literal, TokenStream};
+use tokens::{Literal, TokenStream};
 
 use crate::dom::{Attribute, AttributeValue, CssValue, ElementTag, HtmlElement};
 use crate::gen::{append, DomNode, Generator, IntoGenerator, JsArgument, Short};

--- a/crates/kobold_macros/src/gen/transient.rs
+++ b/crates/kobold_macros/src/gen/transient.rs
@@ -5,7 +5,7 @@
 use std::fmt::{self, Debug, Display, Write};
 
 use arrayvec::ArrayString;
-use proc_macro::{Ident, Literal, TokenStream};
+use tokens::{Ident, Literal, TokenStream};
 
 use crate::gen::element::{Attr, InlineAbi};
 use crate::gen::Short;

--- a/crates/kobold_macros/src/lib.rs
+++ b/crates/kobold_macros/src/lib.rs
@@ -6,10 +6,10 @@
 #![warn(clippy::all, clippy::cast_possible_truncation, clippy::unused_self)]
 
 #[cfg(not(test))]
-extern crate proc_macro;
+extern crate proc_macro as tokens;
 
 #[cfg(test)]
-extern crate proc_macro2 as proc_macro;
+extern crate proc_macro2 as tokens;
 
 use proc_macro::TokenStream;
 
@@ -28,7 +28,7 @@ macro_rules! unwrap_err {
     ($expr:expr) => {
         match $expr {
             Ok(dom) => dom,
-            Err(err) => return err.tokenize(),
+            Err(err) => return err.tokenize().into(),
         }
     };
 }
@@ -36,19 +36,19 @@ macro_rules! unwrap_err {
 #[allow(clippy::let_and_return)]
 #[proc_macro_attribute]
 pub fn component(args: TokenStream, input: TokenStream) -> TokenStream {
-    let args = unwrap_err!(fn_component::args(args));
+    let args = unwrap_err!(fn_component::args(args.into()));
 
-    let out = unwrap_err!(fn_component::component(args, input));
+    let out = unwrap_err!(fn_component::component(args, input.into()));
 
     // panic!("{out}");
 
-    out
+    out.into()
 }
 
 #[allow(clippy::let_and_return)]
 #[proc_macro]
 pub fn view(body: TokenStream) -> TokenStream {
-    let nodes = unwrap_err!(dom::parse(body));
+    let nodes = unwrap_err!(dom::parse(body.into()));
 
     // panic!("{nodes:#?}");
 
@@ -58,5 +58,5 @@ pub fn view(body: TokenStream) -> TokenStream {
 
     // panic!("{out}");
 
-    out
+    out.into()
 }

--- a/crates/kobold_macros/src/parse.rs
+++ b/crates/kobold_macros/src/parse.rs
@@ -6,7 +6,7 @@
 //! token streams without `syn` or `quote`.
 
 use beef::Cow;
-use proc_macro::{Delimiter, Group, Ident, Spacing, Span, TokenStream, TokenTree};
+use tokens::{Delimiter, Group, Ident, Spacing, Span, TokenStream, TokenTree};
 
 use crate::dom::{ShallowNodeIter, ShallowStream};
 use crate::tokenize::prelude::*;
@@ -21,7 +21,7 @@ pub fn parse<T: Parse>(stream: TokenStream) -> Result<T, ParseError> {
     Ok(out)
 }
 
-pub type ParseStream = std::iter::Peekable<proc_macro::token_stream::IntoIter>;
+pub type ParseStream = std::iter::Peekable<tokens::token_stream::IntoIter>;
 
 pub mod prelude {
     pub use super::{parse, IdentExt, IteratorExt, TokenTreeExt};
@@ -340,7 +340,7 @@ mod util {
         }
     }
 
-    impl IdentExt for proc_macro::Ident {}
+    impl IdentExt for tokens::Ident {}
 }
 
 pub use util::IdentExt;

--- a/crates/kobold_macros/src/syntax.rs
+++ b/crates/kobold_macros/src/syntax.rs
@@ -6,7 +6,7 @@
 
 use std::fmt::Write;
 
-use proc_macro::{Ident, Literal, Span, TokenStream};
+use tokens::{Ident, Literal, Span, TokenStream};
 
 use crate::parse::prelude::*;
 use crate::tokenize::prelude::*;

--- a/crates/kobold_macros/src/tokenize.rs
+++ b/crates/kobold_macros/src/tokenize.rs
@@ -6,7 +6,7 @@ use std::cell::RefCell;
 use std::fmt::{Arguments, Write};
 use std::str::FromStr;
 
-use proc_macro::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
+use tokens::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
 
 use crate::parse::ParseStream;
 


### PR DESCRIPTION
Tests on nightly failed as it attempted to use `proc_macro2::TokenStream` in pub signatures.

Instead of importing `proc_macro2 as proc_macro` we import either `proc_macro` or `proc_macro2` as `tokens` and use that as a faux crate name everywhere, so that `proc_macro::TokenStream` always resolves to the correct, undecorated `TokenStream`.