### PR TITLE
Better use of `Maybe`

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ fn Status(code: u32) -> impl View {
 }
 
 view! {
-    // "Status code was 200"
+    // Status code was 200
     <Status />
-    // "Status code was 404"
+    // Status code was 404
     <Status code={404} />
 }
 ```

--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ inside an `if` or `match` expression, and wrap them in an enum making them the s
 #[component(auto_branch)]
 fn Conditional(illuminatus: bool) -> impl View {
     if illuminatus {
-        view! { <p>"It was the year when they finally immanentized the Eschaton."</p> }
+        view! { <p> "It was the year when they finally immanentized the Eschaton." }
     } else {
-        view! { <blockquote>"It was love at first sight."</blockquote> }
+        view! { <blockquote> "It was love at first sight." }
     }
 }
 ```
@@ -170,9 +170,8 @@ fn IterateNumbers(count: u32) -> impl View {
     view! {
         <ul>
         {
-            for (1..=count).map(|n| view! { <li>"Item #"{n}</li> })
+            for (1..=count).map(|n| view! { <li> "Item #"{n} })
         }
-        </ul>
     }
 }
 ```
@@ -195,9 +194,8 @@ fn Users<'a>(names: &'a [&'a str]) -> impl View + 'a {
     view! {
         <ul>
         {
-            for names.iter().map(|name| view! { <li>{ name }</li> })
+            for names.iter().map(|name| view! { <li> { name } })
         }
-        </ul>
     }
 }
 ```

--- a/crates/kobold/src/internal.rs
+++ b/crates/kobold/src/internal.rs
@@ -9,35 +9,6 @@ use web_sys::Node;
 
 use crate::View;
 
-/// Undefined component parameter. If you've encountered this type it usually means
-/// you've failed to set a required component parameter.
-pub struct Undefined;
-
-/// Helper trait for handling optional parameters in components.
-pub trait Maybe<T> {
-    /// This implementation is a no-op that always returns `self`
-    /// for all types but [`Undefined`](Undefined)
-    fn maybe_or(self, or: impl FnOnce() -> T) -> T;
-}
-
-impl<T> Maybe<T> for T
-where
-    T: Default,
-{
-    /// This implementation is a no-op that always returns `self`
-    fn maybe_or(self, _: impl FnOnce() -> T) -> T {
-        self
-    }
-}
-
-impl<T> Maybe<T> for Undefined {
-    /// This implementation is a no-op that always returns the result of
-    /// the `or` closure
-    fn maybe_or(self, or: impl FnOnce() -> T) -> T {
-        or()
-    }
-}
-
 /// Wrapper that turns `extern` precompiled JavaScript functions into [`View`](View)s.
 #[repr(transparent)]
 pub struct Precompiled<F>(pub F);

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -149,9 +149,9 @@
 //! #[component(auto_branch)]
 //! fn Conditional(illuminatus: bool) -> impl View {
 //!     if illuminatus {
-//!         view! { <p>"It was the year when they finally immanentized the Eschaton."</p> }
+//!         view! { <p> "It was the year when they finally immanentized the Eschaton." }
 //!     } else {
-//!         view! { <blockquote>"It was love at first sight."</blockquote> }
+//!         view! { <blockquote> "It was love at first sight." }
 //!     }
 //! }
 //! ```
@@ -170,9 +170,8 @@
 //!     view! {
 //!         <ul>
 //!         {
-//!             for (1..=count).map(|n| view! { <li>"Item #"{n}</li> })
+//!             for (1..=count).map(|n| view! { <li> "Item #"{n} })
 //!         }
-//!         </ul>
 //!     }
 //! }
 //! ```
@@ -196,9 +195,8 @@
 //!     view! {
 //!         <ul>
 //!         {
-//!             for names.iter().map(|name| view! { <li>{ name }</li> })
+//!             for names.iter().map(|name| view! { <li> { name } })
 //!         }
-//!         </ul>
 //!     }
 //! }
 //! ```
@@ -298,9 +296,12 @@
 /// #### Examples
 /// ```
 /// # use kobold::prelude::*;
-/// // `name` will default to `"Kobold"`
-/// // `age` will default to `0` (using `Default`)
-/// #[component(name?: "Kobold", age?)]
+/// #[component(
+///     // `name` will default to `"Kobold"`
+///     name?: "Kobold",
+///     // `age` will default to `0` (using `Default`)
+///     age?,
+/// )]
 /// fn Greeter<'a>(name: &'a str, age: u32) -> impl View + 'a {
 ///     let age = (age > 0).then_some(view!(", you are "{ age }" years old"));
 ///
@@ -368,6 +369,7 @@ pub mod event;
 pub mod internal;
 pub mod keywords;
 pub mod list;
+pub mod maybe;
 
 mod value;
 

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -125,9 +125,9 @@
 //!
 //! # let _ =
 //! view! {
-//!     // "Status code was 200"
+//!     // Status code was 200
 //!     <Status />
-//!     // "Status code was 404"
+//!     // Status code was 404
 //!     <Status code={404} />
 //! }
 //! # ;
@@ -290,20 +290,20 @@
 ///
 /// Allows for parameters to have default values. Available syntax:
 ///
-/// * `#[component(foo?)]`: mark the parameter `foo` as optional, use [`Default`](Default) trait implementation if it's missing.
+/// * `#[component(foo?)]`: mark the parameter `foo` as optional, use [`Default`](Default) trait implementation if absent.
 /// * `#[component(foo?: <expression>)]`: mark the parameter `foo` as optional, default to `<expression>`.
 ///
 /// #### Examples
 /// ```
 /// # use kobold::prelude::*;
 /// #[component(
-///     // `name` will default to `"Kobold"`
+///     // Make `name` an optional parameter, defaults to `"Kobold"`
 ///     name?: "Kobold",
-///     // `age` will default to `0` (using `Default`)
+///     // Make `age` an optional parameter, use the `Default` value
 ///     age?,
 /// )]
-/// fn Greeter<'a>(name: &'a str, age: u32) -> impl View + 'a {
-///     let age = (age > 0).then_some(view!(", you are "{ age }" years old"));
+/// fn Greeter<'a>(name: &'a str, age: Option<u32>) -> impl View + 'a {
+///     let age = age.map(|age| view!(", you are "{ age }" years old"));
 ///
 ///     view! {
 ///         <p> "Hello "{ name }{ age }
@@ -312,12 +312,40 @@
 ///
 /// # let _ =
 /// view! {
-///     // "Hello Kobold"
+///     // Hello Kobold
 ///     <Greeter />
-///     // "Hello Alice"
+///     // Hello Alice
 ///     <Greeter name="Alice" />
-///     // "Hello Bob, you are 42 years old"
+///     // Hello Bob, you are 42 years old
 ///     <Greeter name="Bob" age={42} />
+/// }
+/// # ;
+/// ```
+///
+/// Optional parameters of any type `T` can be set using any type that implements
+/// [`Maybe<T>`](crate::maybe::Maybe).
+///
+/// This allows you to set optional parameters using an [`Option`](Option):
+/// ```
+/// # use kobold::prelude::*;
+/// #[component(code?: 200)]
+/// fn StatusCode(code: u32) -> impl View {
+///     view! {
+///         <p> "Status code was "{ code }
+///     }
+/// }
+///
+/// # let _ =
+/// view! {
+///     // Status code was 200
+///     <StatusCode />
+///     // Status code was 404
+///     <StatusCode code={404} />
+///
+///     // Status code was 200
+///     <StatusCode code={None} />
+///     // Status code was 500
+///     <StatusCode code={Some(500)} />
 /// }
 /// # ;
 /// ```
@@ -338,8 +366,8 @@
 /// #### 💡 Note:
 ///
 /// You can only mark types that implement the [`Default`](Default) trait as optional, even if you provide
-/// a concrete value using `param?: value`. This requirement might be relaxed in the future if trait
-/// specialization is stabilized in Rust.
+/// a concrete value using `param?: value`. This requirement might be relaxed in the future when trait
+/// specialization is stabilized.
 ///
 /// ### Enable auto-branching: `#[component(auto_branch)]`
 ///

--- a/crates/kobold/src/maybe.rs
+++ b/crates/kobold/src/maybe.rs
@@ -6,9 +6,14 @@
 
 /// Undefined component parameter. If you've encountered this type it usually means
 /// you've failed to set a required component parameter.
+///
+/// This is a zero-sized type that implements [`Maybe<T>`](Maybe) for all `T: Default`.
 pub struct Undefined;
 
 /// Helper trait for handling optional parameters in components.
+///
+/// Visit the [`#[component]` macro documentation](crate::component#optional-parameters-componentparam)
+/// to see how it's being used.
 pub trait Maybe<T> {
     fn maybe_or(self, or: impl FnOnce() -> T) -> T;
 }

--- a/crates/kobold/src/maybe.rs
+++ b/crates/kobold/src/maybe.rs
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! The [`Maybe`](Maybe) trait and its implementations
+
+/// Undefined component parameter. If you've encountered this type it usually means
+/// you've failed to set a required component parameter.
+pub struct Undefined;
+
+/// Helper trait for handling optional parameters in components.
+pub trait Maybe<T> {
+    fn maybe_or(self, or: impl FnOnce() -> T) -> T;
+}
+
+impl<T> Maybe<T> for T
+where
+    T: Default,
+{
+    /// This implementation is a no-op that always returns `self`
+    fn maybe_or(self, _: impl FnOnce() -> T) -> T {
+        self
+    }
+}
+
+impl<T> Maybe<T> for Option<T> {
+    fn maybe_or(self, or: impl FnOnce() -> T) -> T {
+        self.unwrap_or_else(or)
+    }
+}
+
+impl<T> Maybe<Option<T>> for T
+where
+    T: Default,
+{
+    fn maybe_or(self, _: impl FnOnce() -> Option<T>) -> Option<T> {
+        Some(self)
+    }
+}
+
+impl<T> Maybe<T> for Undefined {
+    /// This implementation is a no-op that always returns the result of
+    /// the `or` closure
+    fn maybe_or(self, or: impl FnOnce() -> T) -> T {
+        or()
+    }
+}

--- a/examples/default_params/src/main.rs
+++ b/examples/default_params/src/main.rs
@@ -6,8 +6,8 @@ use kobold::prelude::*;
     // Make `age` an optional parameter, use the `Default` trait
     age?,
 )]
-fn Greeter<'a>(name: &'a str, age: u32) -> impl View + 'a {
-    let age = (age > 0).then_some(view!(", you are "{ age }" years old"));
+fn Greeter<'a>(name: &'a str, age: Option<u32>) -> impl View + 'a {
+    let age = age.map(|age| view!(", you are "{ age }" years old"));
 
     view! {
         <p> "Hello "{ name }{ age }
@@ -16,11 +16,11 @@ fn Greeter<'a>(name: &'a str, age: u32) -> impl View + 'a {
 
 fn main() {
     kobold::start(view! {
-        // "Hello Kobold"
+        // Hello Kobold
         <Greeter />
-        // "Hello Alice"
+        // Hello Alice
         <Greeter name="Alice" />
-        // "Hello Bob, you are 42 years old"
+        // Hello Bob, you are 42 years old
         <Greeter name="Bob" age={42} />
     });
 }

--- a/examples/default_params/src/main.rs
+++ b/examples/default_params/src/main.rs
@@ -1,9 +1,9 @@
 use kobold::prelude::*;
 
 #[component(
-    // Make `name` an optional parameter, default to `"Kobold"`
+    // Make `name` an optional parameter, defaults to `"Kobold"`
     name?: "Kobold",
-    // Make `age` an optional parameter, use the `Default` trait
+    // Make `age` an optional parameter, use the `Default` value
     age?,
 )]
 fn Greeter<'a>(name: &'a str, age: Option<u32>) -> impl View + 'a {


### PR DESCRIPTION
+ Extracted the `Maybe` trait into its own module
+ Setters for optional parameters now accept a generic `Maybe<T>` implementation instead of just `T`.
+ Added generic `impl<T> Maybe<Option<T>> for T` and `impl<T> Maybe<T> for Option<T>`.

This makes optional parameter handling really nice without any bloat to the API surface.

Taking an `Option` as a parameter:

```rust
#[component(
    // Make `name` an optional parameter, defaults to `"Kobold"`
    name?: "Kobold",
    // Make `age` an optional parameter, use the `Default` value
    age?,
)]
fn Greeter<'a>(name: &'a str, age: Option<u32>) -> impl View + 'a {
    let age = age.map(|age| view!(", you are "{ age }" years old"));

    view! {
        <p> "Hello "{ name }{ age }
    }
}

view! {
    // Hello Kobold
    <Greeter />
    // Hello Alice
    <Greeter name="Alice" />
    // Hello Bob, you are 42 years old
    <Greeter name="Bob" age={42} />
}
```

Using `Option` to set an optional parameter:

```rust
#[component(code?: 200)]
fn StatusCode(code: u32) -> impl View {
    view! {
        <p> "Status code was "{ code }
    }
}

view! {
    // Status code was 200
    <StatusCode />
    // Status code was 404
    <StatusCode code={404} />

    // Status code was 200
    <StatusCode code={None} />
    // Status code was 500
    <StatusCode code={Some(500)} />
}
```