### PR TITLE
Don't store `JsValue` in `ListenerProduct`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "kobold"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "console_error_panic_hook",
  "itoa",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "kobold_macros"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "arrayvec",
  "beef",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "kobold_qr"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "fast_qr",
  "kobold",

--- a/crates/kobold/Cargo.toml
+++ b/crates/kobold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kobold"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Maciej Hirsz <hello@maciej.codes>"]
 edition = "2021"
 license = "MPL-2.0"
@@ -19,7 +19,7 @@ stateful = []
 wasm-bindgen = "0.2.84"
 wasm-bindgen-futures = "0.4.34"
 itoa = "1.0.6"
-kobold_macros = { version = "0.7.0", path = "../kobold_macros" }
+kobold_macros = { version = "0.8.0", path = "../kobold_macros" }
 console_error_panic_hook = "0.1.7"
 
 [dependencies.web-sys]

--- a/crates/kobold_macros/Cargo.toml
+++ b/crates/kobold_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kobold_macros"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Maciej Hirsz <hello@maciej.codes>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/crates/kobold_macros/src/gen/element.rs
+++ b/crates/kobold_macros/src/gen/element.rs
@@ -143,7 +143,7 @@ impl IntoGenerator for HtmlElement {
                             writeln!(el, "{var}.addEventListener(\"{}\",{value});", &name[2..])
                         });
 
-                        el.args.push(JsArgument::new(value))
+                        el.args.push(JsArgument::with_abi(value, InlineAbi::Event))
                     }
                     AttributeType::Provided(attr) => {
                         el.hoisted = true;
@@ -206,6 +206,7 @@ impl IntoGenerator for HtmlElement {
 pub enum InlineAbi {
     Bool,
     Str,
+    Event,
 }
 
 impl InlineAbi {
@@ -213,13 +214,15 @@ impl InlineAbi {
         match self {
             InlineAbi::Bool => "bool",
             InlineAbi::Str => "&str",
+            InlineAbi::Event => "wasm_bindgen::JsValue",
         }
     }
 
-    pub fn method(self) -> &'static str {
+    pub fn method(self) -> Option<&'static str> {
         match self {
-            InlineAbi::Bool => ".into()",
-            InlineAbi::Str => ".as_ref()",
+            InlineAbi::Bool => Some(".into()"),
+            InlineAbi::Str => Some(".as_ref()"),
+            InlineAbi::Event => None,
         }
     }
 
@@ -227,6 +230,7 @@ impl InlineAbi {
         match self {
             InlineAbi::Bool => "+ Into<bool> + Copy",
             InlineAbi::Str => "+ AsRef<str>",
+            InlineAbi::Event => "",
         }
     }
 }

--- a/crates/kobold_qr/Cargo.toml
+++ b/crates/kobold_qr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kobold_qr"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Maciej Hirsz <hello@maciej.codes>"]
 edition = "2021"
 license = "MPL-2.0"
@@ -10,7 +10,7 @@ description = "QR code component for Kobold"
 
 [dependencies]
 fast_qr = "0.8.5"
-kobold = { version = "0.7.0", path = "../kobold" }
+kobold = { version = "0.8.0", path = "../kobold" }
 wasm-bindgen = "0.2.84"
 
 [dependencies.web-sys]


### PR DESCRIPTION
+ No need to store the `JsValue` for a closure, it's fine to just pass it into the compiled JS code by value.
+ No need to update bound event listeners if the closure they are created from is zero-sized.

This results in a minor reduction in the Wasm file (TodoMVC goes from 35173 bytes to 34986 bytes, uncompressed).