### PR TITLE
Fix `Signal::update`

### DIFF
--- a/crates/kobold/src/stateful/cell.rs
+++ b/crates/kobold/src/stateful/cell.rs
@@ -17,17 +17,19 @@ impl<T> WithCell<T> {
         }
     }
 
-    pub fn with<F>(&self, mutator: F)
+    pub fn with<F, R>(&self, mutator: F) -> R
     where
-        F: FnOnce(&mut T),
+        F: FnOnce(&mut T) -> R,
+        R: 'static,
     {
         if self.borrowed.get() {
             wasm_bindgen::throw_str("Cyclic state borrowing");
         }
 
         self.borrowed.set(true);
-        mutator(unsafe { &mut *self.data.get() });
+        let result = mutator(unsafe { &mut *self.data.get() });
         self.borrowed.set(false);
+        result
     }
 
     pub unsafe fn ref_unchecked(&self) -> &T {

--- a/crates/kobold/src/stateful/hook.rs
+++ b/crates/kobold/src/stateful/hook.rs
@@ -56,11 +56,9 @@ impl<S> Signal<S> {
         O: ShouldRender,
     {
         if let Some(inner) = self.weak.upgrade() {
-            inner.state.with(|state| {
-                if mutator(state).should_render() {
-                    inner.update()
-                }
-            });
+            if inner.state.with(|state| mutator(state)).should_render() {
+                inner.update()
+            }
         }
     }
 

--- a/crates/kobold/src/stateful/should_render.rs
+++ b/crates/kobold/src/stateful/should_render.rs
@@ -7,7 +7,7 @@
 ///
 /// * [`Hook::bind`](crate::stateful::Hook::bind)
 /// * [`IntoState::update`](crate::stateful::IntoState::update)
-pub trait ShouldRender {
+pub trait ShouldRender: 'static {
     fn should_render(self) -> bool;
 }
 


### PR DESCRIPTION
`Signal::update` was triggering view update while the state was still mutably borrowed. This wasn't necessarily causing any soundness issues, but it did fail debug assertions of the `WithCell`