### PR TITLE
Make bound event listeners `Copy`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "kobold"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "console_error_panic_hook",
  "itoa",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "kobold_macros"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "arrayvec",
  "beef",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "kobold_qr"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "fast_qr",
  "kobold",

--- a/crates/kobold/Cargo.toml
+++ b/crates/kobold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kobold"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Maciej Hirsz <hello@maciej.codes>"]
 edition = "2021"
 license = "MPL-2.0"
@@ -19,7 +19,7 @@ stateful = []
 wasm-bindgen = "0.2.84"
 wasm-bindgen-futures = "0.4.34"
 itoa = "1.0.6"
-kobold_macros = { version = "0.8.0", path = "../kobold_macros" }
+kobold_macros = { version = "0.9.0", path = "../kobold_macros" }
 console_error_panic_hook = "0.1.7"
 rlsf = { version = "0.2.1", optional = true }
 

--- a/crates/kobold/src/event.rs
+++ b/crates/kobold/src/event.rs
@@ -83,6 +83,24 @@ event! {
     MouseEvent,
 }
 
+pub trait IntoListener<E: EventCast> {
+    type Listener: Listener<E>;
+
+    fn into_listener(self) -> Self::Listener;
+}
+
+impl<E, L> IntoListener<E> for L
+where
+    L: Listener<E>,
+    E: EventCast,
+{
+    type Listener = L;
+
+    fn into_listener(self) -> L {
+        self
+    }
+}
+
 pub trait Listener<E>
 where
     E: EventCast,

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -585,7 +585,7 @@ macro_rules! class {
 ///     let increment = move |_| *count += 1;
 ///     let decrement = move |_| *count -= 1;
 /// }
-/// # fn throwaway(_: impl kobold::event::Listener<kobold::reexport::web_sys::Event>) {}
+/// # fn throwaway(_: kobold::stateful::Bound<i32, impl FnMut(&mut i32, kobold::reexport::web_sys::Event)>) {}
 /// # throwaway(increment);
 /// # throwaway(decrement);
 /// # }
@@ -597,7 +597,7 @@ macro_rules! class {
 /// # fn test(count: &Hook<i32>) {
 /// let increment = count.bind(move |count, _| *count += 1);
 /// let decrement = count.bind(move |count, _| *count -= 1);
-/// # fn throwaway(_: impl kobold::event::Listener<kobold::reexport::web_sys::Event>) {}
+/// # fn throwaway(_: kobold::stateful::Bound<i32, impl FnMut(&mut i32, kobold::reexport::web_sys::Event)>) {}
 /// # throwaway(increment);
 /// # throwaway(decrement);
 /// # }

--- a/crates/kobold/src/stateful.rs
+++ b/crates/kobold/src/stateful.rs
@@ -31,7 +31,7 @@ mod should_render;
 use cell::WithCell;
 use product::{Product, ProductHandler};
 
-pub use hook::{Hook, Signal};
+pub use hook::{Bound, Hook, Signal};
 pub use into_state::IntoState;
 pub use should_render::{ShouldRender, Then};
 

--- a/crates/kobold/src/stateful/product.rs
+++ b/crates/kobold/src/stateful/product.rs
@@ -26,6 +26,17 @@ pub struct ProductHandler<S, P, F> {
     _state: PhantomData<S>,
 }
 
+#[cfg(test)]
+impl<S, P, F> ProductHandler<S, P, F> {
+    pub(crate) fn mock(updater: F, product: P) -> Self {
+        ProductHandler {
+            updater,
+            product,
+            _state: PhantomData,
+        }
+    }
+}
+
 impl<S, P, F> ProductHandler<S, P, F> {
     pub fn build<V>(updater: F, view: V, p: In<Self>) -> Out<Self>
     where

--- a/crates/kobold/src/value.rs
+++ b/crates/kobold/src/value.rs
@@ -59,8 +59,8 @@ impl_value!(bool: bool);
 impl_value!(f64: u8, u16, u32, usize, i8, i16, i32, isize, f32, f64);
 
 pub struct TextProduct<M> {
-    memo: M,
-    node: Node,
+    pub(crate) memo: M,
+    pub(crate) node: Node,
 }
 
 impl<M> Anchor for TextProduct<M> {

--- a/crates/kobold_macros/Cargo.toml
+++ b/crates/kobold_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kobold_macros"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Maciej Hirsz <hello@maciej.codes>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/crates/kobold_macros/src/gen/element.rs
+++ b/crates/kobold_macros/src/gen/element.rs
@@ -134,7 +134,7 @@ impl IntoGenerator for HtmlElement {
                                 expr.stream,
                             )
                         } else {
-                            expr.stream
+                            (expr.stream, ".into_listener()").tokenize()
                         };
 
                         let value = gen.add_field(coerce).event(event, el.typ).name;

--- a/crates/kobold_macros/src/gen/transient.rs
+++ b/crates/kobold_macros/src/gen/transient.rs
@@ -184,6 +184,7 @@ impl Tokenize for Transient {
                 "\
                 use ::kobold::dom::Mountable as _;\
                 use ::kobold::event::ListenerHandle as _;\
+                use ::kobold::event::IntoListener as _;\
                 use ::kobold::reexport::wasm_bindgen;\
                 ",
                 self.js,

--- a/crates/kobold_qr/Cargo.toml
+++ b/crates/kobold_qr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kobold_qr"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Maciej Hirsz <hello@maciej.codes>"]
 edition = "2021"
 license = "MPL-2.0"
@@ -10,7 +10,7 @@ description = "QR code component for Kobold"
 
 [dependencies]
 fast_qr = "0.8.5"
-kobold = { version = "0.8.0", path = "../kobold" }
+kobold = { version = "0.9.0", path = "../kobold" }
 wasm-bindgen = "0.2.84"
 
 [dependencies.web-sys]


### PR DESCRIPTION
This should now be legal:

```rust
bind! {
    state:

    let reset = |_| *state = 0;
}

view! {
    // `reset` previously was of `impl Listener<_>` type that made it `!Copy`
    <input onclick={reset} onchange={reset}>
}
```