### PR TITLE
Add Support for HTML Tags with Namespace and use it to Support SVG Tags

### DIFF
--- a/crates/kobold_macros/src/gen.rs
+++ b/crates/kobold_macros/src/gen.rs
@@ -92,10 +92,12 @@ impl Generator {
                 args,
                 hoisted: _,
             }) => {
+                let create_tag = tag.to_js_create_element();
+
                 let body = if code.is_empty() {
-                    format!("return document.createElement(\"{tag:?}\");\n")
+                    format!("return {create_tag};\n")
                 } else {
-                    format!("let {var}=document.createElement(\"{tag:?}\");\n{code}return {var};\n")
+                    format!("let {var}={create_tag};\n{code}return {var};\n")
                 };
 
                 (var, body, args, Anchor::Element(typ))

--- a/crates/kobold_macros/src/gen/fragment.rs
+++ b/crates/kobold_macros/src/gen/fragment.rs
@@ -64,11 +64,8 @@ pub fn append(
 
                     args.push(JsArgument::new(var));
                 } else {
-                    let _ = writeln!(
-                        js,
-                        "let {}=document.createElement(\"{}\");",
-                        el.var, &*el.tag
-                    );
+                    let create_tag = el.tag.to_js_create_element();
+                    let _ = writeln!(js, "let {}={create_tag};", el.var);
 
                     js.push_str(&el.code);
 


### PR DESCRIPTION
This PR adds allows to define HTLM tags with a namespace in the macro sub-crate, which allows defining SVG tags and thus allowing users to create SVGs via the `view!` macro.

E.g.:

```rust
fn main() {
    kobold::start(kobold::view! {
        <svg width="100" height="100">
            <circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow" />
        </svg>
    });
}
```