### PR TITLE
New `event!` macro deprecating `bind!`

### DIFF
--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -434,7 +434,7 @@ use internal::{In, Out};
 /// ```
 pub mod prelude {
     pub use crate::event::{Event, KeyboardEvent, MouseEvent};
-    pub use crate::{bind, class};
+    pub use crate::{bind, event, class};
     pub use crate::{component, view, View};
 
     #[cfg(feature = "stateful")]
@@ -614,5 +614,32 @@ macro_rules! bind {
         $(
             let $v = $hook.bind(move |$hook, $e $(: $e_ty)*| $body);
         )*
+    };
+}
+
+#[macro_export]
+macro_rules! event {
+    (move |$state:ident| $body:expr) => {
+        $state.bind(move |$state, _| $body)
+    };
+
+    (move |$state:ident, $e:tt $(: $e_ty:ty)?| $body:expr) => {
+        $state.bind(move |$state, $e $(: $e_ty)*| $body)
+    };
+
+    (|$state:ident| $body:expr) => {
+        $state.bind(|$state, _| $body)
+    };
+
+    (|$state:ident, $e:tt $(: $e_ty:ty)?| $body:expr) => {
+        $state.bind(|$state, $e $(: $e_ty)*| $body)
+    };
+
+    (*$state:ident $($body:tt)+) => {
+        $state.bind(move |$state, _| *$state $($body)*)
+    };
+
+    ($state:ident $($body:tt)+) => {
+        $state.bind(move |$state, _| $state $($body)*)
     };
 }

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -434,7 +434,7 @@ use internal::{In, Out};
 /// ```
 pub mod prelude {
     pub use crate::event::{Event, KeyboardEvent, MouseEvent};
-    pub use crate::{bind, event, class};
+    pub use crate::{bind, class, event};
     pub use crate::{component, view, View};
 
     #[cfg(feature = "stateful")]

--- a/examples/counter/Trunk.toml
+++ b/examples/counter/Trunk.toml
@@ -1,2 +1,0 @@
-[tools]
-wasm_bindgen = "0.2.84"

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -1,10 +1,8 @@
 use kobold::prelude::*;
 
 fn app(count: &Hook<u32>) -> impl View + '_ {
-    bind! { count:
-        let onclick = move |_| *count += 1;
-        let reset = move |_| *count = 0;
-    }
+    let onclick = event!(*count += 1);
+    let reset = event!(*count = 0);
 
     view! {
         <p>

--- a/examples/csv_editor/Trunk.toml
+++ b/examples/csv_editor/Trunk.toml
@@ -1,2 +1,0 @@
-[tools]
-wasm_bindgen = "0.2.84"

--- a/examples/csv_editor/src/main.rs
+++ b/examples/csv_editor/src/main.rs
@@ -22,19 +22,15 @@ fn editor() -> impl View {
             }
         });
 
-        bind! {
-            state:
+        let onkeydown = event!(move |state, e: KeyboardEvent<_>| {
+            if matches!(e.key().as_str(), "Esc" | "Escape") {
+                state.editing = Editing::None;
 
-            let onkeydown = move |event: KeyboardEvent<_>| {
-                if matches!(event.key().as_str(), "Esc" | "Escape") {
-                    state.editing = Editing::None;
-
-                    Then::Render
-                } else {
-                    Then::Stop
-                }
-            };
-        }
+                Then::Render
+            } else {
+                Then::Stop
+            }
+        });
 
         view! {
             <input type="file" accept="text/csv" onchange={onload}>
@@ -85,14 +81,10 @@ fn cell(col: usize, row: usize, state: &Hook<State>) -> impl View + '_ {
     let value = state.source.get_text(&state.rows[row][col]);
 
     if state.editing == (Editing::Cell { row, col }) {
-        bind! {
-            state:
-
-            let onchange = move |e: Event<InputElement>| {
-                state.rows[row][col] = Text::Owned(e.target().value().into());
-                state.editing = Editing::None;
-            };
-        }
+        let onchange = event!(move |state, e: Event<InputElement>| {
+            state.rows[row][col] = Text::Owned(e.target().value().into());
+            state.editing = Editing::None;
+        });
 
         let mut selected = false;
 

--- a/examples/hello_world/Trunk.toml
+++ b/examples/hello_world/Trunk.toml
@@ -1,2 +1,0 @@
-[tools]
-wasm_bindgen = "0.2.84"

--- a/examples/interval/Trunk.toml
+++ b/examples/interval/Trunk.toml
@@ -1,2 +1,0 @@
-[tools]
-wasm_bindgen = "0.2.84"

--- a/examples/interval/src/main.rs
+++ b/examples/interval/src/main.rs
@@ -4,11 +4,7 @@ use kobold::prelude::*;
 #[component]
 fn elapsed(seconds: u32) -> impl View {
     stateful(seconds, |seconds| {
-        bind! {
-            seconds:
-
-            let onclick = move |_| *seconds = 0;
-        }
+        let onclick = event!(*seconds = 0);
 
         view! {
             <p>

--- a/examples/list/Trunk.toml
+++ b/examples/list/Trunk.toml
@@ -1,2 +1,0 @@
-[tools]
-wasm_bindgen = "0.2.84"

--- a/examples/list/src/main.rs
+++ b/examples/list/src/main.rs
@@ -3,10 +3,8 @@ use kobold::prelude::*;
 #[component]
 fn list_example(count: u32) -> impl View {
     stateful(count, |count| {
-        bind! { count:
-            let dec = move |_| *count = count.saturating_sub(1);
-            let inc = move |_| *count += 1;
-        }
+        let dec = event!(*count = count.saturating_sub(1));
+        let inc = event!(*count += 1);
 
         view! {
             <div>

--- a/examples/optional_params/Trunk.toml
+++ b/examples/optional_params/Trunk.toml
@@ -1,2 +1,0 @@
-[tools]
-wasm_bindgen = "0.2.84"

--- a/examples/qrcode/Trunk.toml
+++ b/examples/qrcode/Trunk.toml
@@ -1,8 +1,3 @@
-[tools]
-wasm_bindgen = "0.2.84"
-
 [build]
 filehash = false
-
-# Does not work with `trunk serve`
-# public_url = "./"
+public_url = "./"

--- a/examples/qrcode/src/main.rs
+++ b/examples/qrcode/src/main.rs
@@ -5,11 +5,9 @@ use kobold_qr::qr;
 #[component]
 fn qr_example() -> impl View {
     stateful("Enter something", |data| {
-        bind! {
-            data:
-
-            let onkeyup = move |event: KeyboardEvent<HtmlTextAreaElement>| *data = event.target().value();
-        }
+        let onkeyup = event!(|data, e: KeyboardEvent<HtmlTextAreaElement>| {
+            *data = e.target().value();
+        });
 
         view! {
             <h1>"QR code example"</h1>

--- a/examples/stateful/Trunk.toml
+++ b/examples/stateful/Trunk.toml
@@ -1,2 +1,0 @@
-[tools]
-wasm_bindgen = "0.2.84"

--- a/examples/stateful/src/main.rs
+++ b/examples/stateful/src/main.rs
@@ -16,22 +16,22 @@ impl State {
 }
 
 fn app(state: &Hook<State>) -> impl View + '_ {
-    bind! { state:
-        // Since we work with a state that owns a `String`,
-        // callbacks can mutate it at will.
-        let exclaim = move |_| state.name.push('!');
+    // Since we work with a state that owns a `String`,
+    // callbacks can mutate it at will.
+    let exclaim = event!(state.name.push('!'));
 
-        // Repeatedly clicking the Alice button does not have to do anything.
-        let alice = move |_| if state.name != "Alice" {
+    // Repeatedly clicking the Alice button does not have to do anything.
+    let alice = event!(|state| {
+        if state.name != "Alice" {
             "Alice".clone_into(&mut state.name);
             Then::Render
         } else {
             Then::Stop
-        };
+        }
+    });
 
-        let inc_age = move |_| state.age += 1;
-        let adult = move |_| state.age = 18;
-    }
+    let inc_age = event!(state.age += 1);
+    let adult = event!(state.age = 18);
 
     view! {
         <div>

--- a/examples/todomvc/Trunk.toml
+++ b/examples/todomvc/Trunk.toml
@@ -1,8 +1,3 @@
-[tools]
-wasm_bindgen = "0.2.84"
-
 [build]
 filehash = false
-
-# Does not work with `trunk serve`
-# public_url = "./"
+public_url = "./"


### PR DESCRIPTION
New abstraction over `Hook::bind`, all of the following lines are equivalent:

```rust
// no sugar
let onclick = counter.bind(|counter, _| *counter += 1);

// old bind! macro
bind! {
    counter:

    let onclick = |_| *counter += 1;
}

// new event! macro long form
let onclick = event!(|counter, _| *counter += 1);

// new event! macro skipping event in closure
let onclick = event!(|counter| *counter += 1);

// new event! macro shorthand
let onclick = event!(*counter += 1);
```

The shorthand variant works only if the expression begins either with the same identifier as the `&Hook` to the state, or deref asterisk followed by the same identifier like in the example alone. Aside from assignment like above, this makes the following scenarios very ergonomic:

```rust
/// assigning a field on a struct
let onclick = event!(state.some_field = value);

/// calling a method
let onclick = event!(state.some_method());
```