### PR TITLE
`do` keyword as an alias to the `event!` macro

### DIFF
--- a/crates/kobold/src/event.rs
+++ b/crates/kobold/src/event.rs
@@ -138,7 +138,7 @@ pub struct ListenerProduct<F, E> {
 }
 
 pub trait ListenerHandle {
-    fn js(&mut self) -> JsValue;
+    fn js_value(&mut self) -> JsValue;
 }
 
 impl<F, E> ListenerHandle for ListenerProduct<F, E>
@@ -146,7 +146,7 @@ where
     F: FnMut(E) + 'static,
     E: EventCast,
 {
-    fn js(&mut self) -> JsValue {
+    fn js_value(&mut self) -> JsValue {
         let vcall: fn(E, *mut ()) = |e, ptr| unsafe { (*(ptr as *mut F))(e) };
 
         internal::make_event_handler((&mut self.closure) as *mut F as *mut (), vcall as usize)

--- a/crates/kobold/src/keywords.rs
+++ b/crates/kobold/src/keywords.rs
@@ -70,3 +70,6 @@ pub const fn r#use<T>(value: T) -> Eager<T> {
 pub const fn r#static<T>(value: T) -> Static<T> {
     Static(value)
 }
+
+/// `{ do ... }` is an alias for [`{ event!(...) }`](../macro.event.html)
+pub use crate::event as r#do;

--- a/crates/kobold_macros/src/dom/expression.rs
+++ b/crates/kobold_macros/src/dom/expression.rs
@@ -53,6 +53,7 @@ impl From<Group> for Expression {
             let span = ident.span();
             let mut is_static = false;
             let mut deref = false;
+            let mut invoke = false;
 
             let keyword = ident.with_str(|ident| match ident {
                 "for" | "use" => Some(Ident::new_raw(ident, span)),
@@ -66,6 +67,11 @@ impl From<Group> for Expression {
 
                     Some(Ident::new_raw(ident, span))
                 }
+                "do" => {
+                    invoke = true;
+
+                    Some(Ident::new_raw(ident, span))
+                }
                 _ => None,
             });
 
@@ -74,7 +80,7 @@ impl From<Group> for Expression {
 
                 return Expression {
                     stream: call(
-                        ("::kobold::keywords::", keyword),
+                        ("::kobold::keywords::", keyword, invoke.then_some('!')),
                         (deref.then_some('&'), stream),
                     ),
                     span: group.span(),

--- a/crates/kobold_macros/src/gen/element.rs
+++ b/crates/kobold_macros/src/gen/element.rs
@@ -220,14 +220,6 @@ impl InlineAbi {
         }
     }
 
-    pub fn method(self) -> Option<&'static str> {
-        match self {
-            InlineAbi::Bool => Some(".into()"),
-            InlineAbi::Str => Some(".as_ref()"),
-            InlineAbi::Event => None,
-        }
-    }
-
     pub fn bound(self) -> &'static str {
         match self {
             InlineAbi::Bool => "+ Into<bool> + Copy",

--- a/crates/kobold_macros/src/gen/transient.rs
+++ b/crates/kobold_macros/src/gen/transient.rs
@@ -160,11 +160,9 @@ impl Tokenize for Transient {
                 .iter()
                 .map(|a| {
                     let mut temp = ArrayString::<24>::new();
-                    let name = a.name;
-                    let _ = match a.abi.and_then(|abi| abi.method()) {
-                        Some(method) => write!(temp, "self.{name}{method}"),
-                        None => write!(temp, "{name}.js()"),
-                    };
+
+                    let _ = write!(temp, "{a}");
+
                     temp
                 })
                 .join(",");
@@ -347,6 +345,19 @@ impl JsArgument {
         JsArgument {
             name,
             abi: Some(abi),
+        }
+    }
+}
+
+impl Display for JsArgument {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = self.name;
+
+        match self.abi {
+            Some(InlineAbi::Bool) => write!(f, "self.{name}.into()"),
+            Some(InlineAbi::Str) => write!(f, "self.{name}.as_ref()"),
+            Some(InlineAbi::Event) => write!(f, "{name}.js_value()"),
+            None => write!(f, "{name}.js()"),
         }
     }
 }

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -1,16 +1,12 @@
 use kobold::prelude::*;
 
 fn app(count: &Hook<u32>) -> impl View + '_ {
-    let onclick = event!(*count += 1);
-    let reset = event!(*count = 0);
-
     view! {
         <p>
             <!counter count={count.get()}>
 
-            // `{onclick}` here is shorthand for `onclick={onclick}`
-            <button {onclick}>"Click me!"</button>
-            <button onclick={reset}>"Reset"</button>
+            <button onclick={do *count += 1}>"Click me!"</button>
+            <button onclick={do *count = 0}>"Reset"</button>
     }
 }
 

--- a/examples/interval/src/main.rs
+++ b/examples/interval/src/main.rs
@@ -4,13 +4,10 @@ use kobold::prelude::*;
 #[component]
 fn elapsed(seconds: u32) -> impl View {
     stateful(seconds, |seconds| {
-        let onclick = event!(*seconds = 0);
-
         view! {
             <p>
                 "Elapsed seconds: "{ seconds }" "
-                // `{onclick}` here is shorthand for `onclick={onclick}`
-                <button {onclick}>"Reset"</button>
+                <button onclick={do *seconds = 0}>"Reset"</button>
         }
     })
     .once(|signal| {

--- a/examples/list/src/main.rs
+++ b/examples/list/src/main.rs
@@ -3,17 +3,14 @@ use kobold::prelude::*;
 #[component]
 fn list_example(count: u32) -> impl View {
     stateful(count, |count| {
-        let dec = event!(*count = count.saturating_sub(1));
-        let inc = event!(*count += 1);
-
         view! {
             <div>
                 <h1 class="Greeter">"List example"</h1>
                 <p>
                     "This component dynamically creates a list from a range iterator ending at "
-                    <button onclick={dec}>"-"</button>
+                    <button onclick={do *count = count.saturating_sub(1)}>"-"</button>
                     " "{ count }" "
-                    <button onclick={inc}>"+"</button>
+                    <button onclick={do *count += 1}>"+"</button>
                 </p>
                 <ul>
                 {

--- a/examples/stateful/src/main.rs
+++ b/examples/stateful/src/main.rs
@@ -16,10 +16,6 @@ impl State {
 }
 
 fn app(state: &Hook<State>) -> impl View + '_ {
-    // Since we work with a state that owns a `String`,
-    // callbacks can mutate it at will.
-    let exclaim = event!(state.name.push('!'));
-
     // Repeatedly clicking the Alice button does not have to do anything.
     let alice = event!(|state| {
         if state.name != "Alice" {
@@ -30,18 +26,15 @@ fn app(state: &Hook<State>) -> impl View + '_ {
         }
     });
 
-    let inc_age = event!(state.age += 1);
-    let adult = event!(state.age = 18);
-
     view! {
         <div>
             // Render can borrow `name` from state, no need for clones
             <h1>{ &state.name }" is "{ state.age }" years old."</h1>
             <button onclick={alice}>"Alice"</button>
-            <button onclick={exclaim}>"!"</button>
+            <button onclick={do state.name.push('!')}>"!"</button>
             " "
-            <button onclick={adult}>"18"</button>
-            <button onclick={inc_age}>"+"</button>
+            <button onclick={do state.age = 18}>"18"</button>
+            <button onclick={do state.age += 1}>"+"</button>
     }
 }
 

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -11,8 +11,6 @@ fn app(state: &Hook<State>) -> impl View + '_ {
     let active_count = state.count_active();
     let completed_hidden = class!("hidden" if state.entries.len() == active_count);
 
-    let clear = event!(state.clear());
-
     view! {
         <div.todomvc-wrapper>
             <section.todoapp>
@@ -44,7 +42,7 @@ fn app(state: &Hook<State>) -> impl View + '_ {
                         <!filter by={Filter::Active} {state}>
                         <!filter by={Filter::Completed} {state}>
                     </ul>
-                    <button.clear-completed.{completed_hidden} onclick={clear}> "Clear completed"
+                    <button.clear-completed.{completed_hidden} onclick={do state.clear()}> "Clear completed"
             </section>
             <footer.info>
                 <p> "Double-click to edit a todo"
@@ -69,10 +67,12 @@ fn entry_input(state: &Hook<State>) -> impl View + '_ {
 
 #[component]
 fn toggle_all(active_count: usize, state: &Hook<State>) -> impl View + '_ {
-    let onclick = event!(state.set_all(active_count != 0));
-
     view! {
-        <input #toggle-all.toggle-all type="checkbox" checked={active_count == 0} {onclick}>
+        <input #toggle-all.toggle-all
+            type="checkbox"
+            checked={active_count == 0}
+            onclick={do state.set_all(active_count != 0)}
+        >
         <label for="toggle-all">
     }
 }
@@ -104,21 +104,17 @@ fn entry<'a>(idx: usize, entry: &'a Entry, state: &'a Hook<State>) -> impl View 
         }
     });
 
-    let onchange = event!(state.toggle(idx));
-    let edit = event!(state.edit_entry(idx));
-    let remove = event!(state.remove(idx));
-
     let editing = class!("editing" if entry.editing);
     let completed = class!("completed" if entry.completed);
 
     view! {
         <li.todo.{editing}.{completed}>
             <div.view>
-                <input.toggle type="checkbox" checked={entry.completed} {onchange}>
-                <label ondblclick={edit} >
+                <input.toggle type="checkbox" checked={entry.completed} onchange={do state.toggle(idx)}>
+                <label ondblclick={do state.edit_entry(idx)} >
                     { ref entry.description }
                 </label>
-                <button.destroy onclick={remove}>
+                <button.destroy onclick={do state.remove(idx)}>
             </div>
             { input }
     }
@@ -126,13 +122,11 @@ fn entry<'a>(idx: usize, entry: &'a Entry, state: &'a Hook<State>) -> impl View 
 
 #[component]
 fn filter(by: Filter, state: &Hook<State>) -> impl View + '_ {
-    let selected = state.filter;
-    let class = class!("selected" if selected == by);
-    let onclick = event!(state.filter = by);
+    let class = class!("selected" if state.filter == by);
 
     view! {
         <li>
-            <a {class} {onclick} href={static by.href()}>
+            <a {class} onclick={do state.filter = by} href={static by.href()}>
                 { static by.label() }
     }
 }


### PR DESCRIPTION
Really concise inline event handlers:

```rust
view! {
    // No sugar:
    <input onclick={event!(state.foo = 42)}>

    // Equivalent using the `do` keyword:
    <input onclick={do state.foo = 42}>
}
```