### PR TITLE
Raw HTML, fixes/improvements for: SVG, event target, kobold_qr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,12 +72,9 @@ checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
 
 [[package]]
 name = "fast_qr"
-version = "0.8.5"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2688af7b0627fca756414f1378bf1b2ab4418f541dda829514b2fcb4fa828eb9"
-dependencies = [
- "wasm-bindgen",
-]
+checksum = "e3251e51cec6f8085d67b30363e51f35f40dde45e25507815559a9321ed4c251"
 
 [[package]]
 name = "fnv"

--- a/crates/kobold/Cargo.toml
+++ b/crates/kobold/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1", optional = true }
 version = "0.3"
 features = [
   "Document",
+  "DomStringMap",
   "Element",
   "Event",
   "MouseEvent",

--- a/crates/kobold/js/util.js
+++ b/crates/kobold/js/util.js
@@ -35,6 +35,7 @@ export function setAttribute(n,a,v) { n.setAttribute(a, v); }
 
 export function setChecked(n,v) { if (n.checked !== v) n.checked = v; }
 export function setClassName(n,v) { n.className = v; }
+export function setInnerHTML(n,v) { n.innerHTML = v; }
 export function setHref(n,v) { n.href = v; }
 export function setStyle(n,v) { n.style = v; }
 export function setValue(n,v) { n.value = v; }

--- a/crates/kobold/src/attribute.rs
+++ b/crates/kobold/src/attribute.rs
@@ -72,6 +72,8 @@ attribute!(
     Checked [checked: bool]
     /// The `className` attribute: <https://developer.mozilla.org/en-US/docs/Web/API/Element/className>
     ClassName [class_name: &str]
+    /// The `innerHTML` attribute: <https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML>
+    InnerHtml [inner_html: &str]
     /// The `style` attribute: <https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style>
     Style [style: &str]
     /// The `href` attribute: <https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/href>

--- a/crates/kobold/src/diff.rs
+++ b/crates/kobold/src/diff.rs
@@ -117,6 +117,26 @@ pub trait Diff: Copy {
     fn diff(self, memo: &mut Self::Memo) -> bool;
 }
 
+impl<T> Diff for Option<T>
+where
+    T: Copy + Eq + 'static,
+{
+    type Memo = Self;
+
+    fn into_memo(self) -> Self {
+        self
+    }
+
+    fn diff(self, memo: &mut Self) -> bool {
+        if self != *memo {
+            *memo = self;
+            true
+        } else {
+            false
+        }
+    }
+}
+
 macro_rules! impl_diff_str {
     ($($ty:ty),*) => {
         $(

--- a/crates/kobold/src/event.rs
+++ b/crates/kobold/src/event.rs
@@ -19,6 +19,9 @@ extern "C" {
 
     #[wasm_bindgen(method, getter)]
     fn target(this: &EventWithTarget) -> HtmlElement;
+
+    #[wasm_bindgen(method, getter, js_name = "currentTarget")]
+    fn current_target(this: &EventWithTarget) -> HtmlElement;
 }
 
 macro_rules! event {
@@ -55,11 +58,19 @@ macro_rules! event {
                 ///
                 /// This method shadows over the [`Event::target`](web_sys::Event::target)
                 /// method provided by `web-sys` and makes it infallible.
-                pub fn target(&self) -> EventTarget<T>
+                pub fn target(&self) -> HtmlElement {
+                    self.event.unchecked_ref::<EventWithTarget>().target().unchecked_into()
+                }
+
+                /// Return a reference to the target element.
+                ///
+                /// This method shadows over the [`Event::target`](web_sys::Event::target)
+                /// method provided by `web-sys` and makes it infallible.
+                pub fn current_target(&self) -> EventTarget<T>
                 where
                     T: JsCast,
                 {
-                    EventTarget(self.event.unchecked_ref::<EventWithTarget>().target().unchecked_into())
+                    EventTarget(self.event.unchecked_ref::<EventWithTarget>().current_target().unchecked_into())
                 }
             }
         )*

--- a/crates/kobold/src/internal.rs
+++ b/crates/kobold/src/internal.rs
@@ -267,6 +267,8 @@ extern "C" {
     pub(crate) fn checked(node: &Node, value: bool);
     #[wasm_bindgen(js_name = "setClassName")]
     pub(crate) fn class_name(node: &Node, value: &str);
+    #[wasm_bindgen(js_name = "setInnerHTML")]
+    pub(crate) fn inner_html(node: &Node, value: &str);
     #[wasm_bindgen(js_name = "setHref")]
     pub(crate) fn href(node: &Node, value: &str);
     #[wasm_bindgen(js_name = "setStyle")]

--- a/crates/kobold_macros/src/gen/element.rs
+++ b/crates/kobold_macros/src/gen/element.rs
@@ -52,9 +52,9 @@ impl IntoGenerator for HtmlElement {
             hoisted: false, // None, // self.classes.iter().any(CssValue::is_expression),
         };
 
-        match self.classes.len() {
-            0 => (),
-            1 => match self.classes.remove(0) {
+        match (self.classes.len(), el.tag.namespace().is_none()) {
+            (0, _) => (),
+            (1, true) => match self.classes.remove(0) {
                 CssValue::Literal(class) => writeln!(el, "{var}.className={class};"),
                 CssValue::Expression(expr) => {
                     el.hoisted = true;

--- a/crates/kobold_macros/src/gen/element.rs
+++ b/crates/kobold_macros/src/gen/element.rs
@@ -112,6 +112,7 @@ impl IntoGenerator for HtmlElement {
 
             match value {
                 AttributeValue::Literal(value) => {
+                    let name = attribute_name(&name.label);
                     writeln!(el, "{var}.setAttribute(\"{name}\",{value});");
                 }
                 AttributeValue::Boolean(value) => {
@@ -148,6 +149,7 @@ impl IntoGenerator for HtmlElement {
                         el.args.push(JsArgument::with_abi(value, InlineAbi::Event))
                     }
                     AttributeType::Provided(attr) => {
+                        let name = attribute_name(&name.label);
                         el.hoisted = true;
 
                         let value = gen
@@ -278,6 +280,14 @@ fn is_inline_closure(out: &mut TokenStream) -> bool {
     is_closure
 }
 
+fn attribute_name(attr: &str) -> &str {
+    match attr {
+        "html" => "innerHTML",
+        "view_box" => "viewBox",
+        name => name,
+    }
+}
+
 fn attribute_type(attr: &str) -> AttributeType {
     if attr.starts_with("on") && attr.len() > 2 {
         return AttributeType::Event(event_js_type(&attr[2..]));
@@ -290,6 +300,10 @@ fn attribute_type(attr: &str) -> AttributeType {
         },
         "href" => Attr {
             name: "Href",
+            abi: Some(InlineAbi::Str),
+        },
+        "html" => Attr {
+            name: "InnerHtml",
             abi: Some(InlineAbi::Str),
         },
         "style" => Attr {

--- a/crates/kobold_qr/Cargo.toml
+++ b/crates/kobold_qr/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["web", "wasm", "javascript", "qr"]
 description = "QR code component for Kobold"
 
 [dependencies]
-fast_qr = "0.8.5"
+fast_qr = { version = "0.12.1" }
 kobold = { version = "0.10.0", path = "../kobold" }
 wasm-bindgen = "0.2.84"
 

--- a/crates/kobold_qr/src/lib.rs
+++ b/crates/kobold_qr/src/lib.rs
@@ -9,10 +9,42 @@ use fast_qr::qr::QRBuilder;
 use kobold::diff::fence;
 use web_sys::CanvasRenderingContext2d;
 
-#[component(size?: 200)]
-pub fn qr(data: &str, size: usize) -> impl View + '_ {
+/// Error Correction Coding has 4 levels
+pub enum Ecl {
+    /// Low, 7%
+    L,
+    /// Medium, 15%
+    M,
+    /// Quartile, 25%
+    Q,
+    /// High, 30%
+    H,
+}
+
+impl From<Ecl> for fast_qr::ECL {
+    fn from(value: Ecl) -> Self {
+        match value {
+            Ecl::L => fast_qr::ECL::L,
+            Ecl::M => fast_qr::ECL::M,
+            Ecl::Q => fast_qr::ECL::Q,
+            Ecl::H => fast_qr::ECL::H,
+        }
+    }
+}
+
+impl Default for Ecl {
+    fn default() -> Self {
+        Ecl::Q
+    }
+}
+
+#[component(
+    size?: 200,
+    ecl?,
+)]
+pub fn qr(data: &str, size: usize, ecl: Ecl) -> impl View + '_ {
     fence(data, move || {
-        let qr = QRBuilder::new(data).build().ok()?;
+        let qr = QRBuilder::new(data).ecl(ecl.into()).build().ok()?;
         let pixel = ((size / qr.size) + 1) * 2;
         let pixels = qr.size * pixel;
         let style = format!("width: {size}px; height: {size}px;");

--- a/examples/csv_editor/src/main.rs
+++ b/examples/csv_editor/src/main.rs
@@ -10,7 +10,7 @@ use state::{Editing, State, Text};
 fn editor() -> impl View {
     stateful(State::mock, |state| {
         let onload = state.bind_async(|state, event: Event<InputElement>| async move {
-            let file = match event.target().files().and_then(|list| list.get(0)) {
+            let file = match event.current_target().files().and_then(|list| list.get(0)) {
                 Some(file) => file,
                 None => return,
             };
@@ -60,7 +60,7 @@ fn head(col: usize, state: &Hook<State>) -> impl View + '_ {
 
     if state.editing == (Editing::Column { col }) {
         let onchange = state.bind(move |state, e: Event<InputElement>| {
-            state.columns[col] = Text::Owned(e.target().value().into());
+            state.columns[col] = Text::Owned(e.current_target().value().into());
             state.editing = Editing::None;
         });
 
@@ -82,7 +82,7 @@ fn cell(col: usize, row: usize, state: &Hook<State>) -> impl View + '_ {
 
     if state.editing == (Editing::Cell { row, col }) {
         let onchange = event!(move |state, e: Event<InputElement>| {
-            state.rows[row][col] = Text::Owned(e.target().value().into());
+            state.rows[row][col] = Text::Owned(e.current_target().value().into());
             state.editing = Editing::None;
         });
 
@@ -90,7 +90,7 @@ fn cell(col: usize, row: usize, state: &Hook<State>) -> impl View + '_ {
 
         let onmouseenter = move |e: MouseEvent<InputElement>| {
             if !selected {
-                let input = e.target();
+                let input = e.current_target();
                 input.focus();
                 input.select();
                 selected = true;

--- a/examples/qrcode/src/main.rs
+++ b/examples/qrcode/src/main.rs
@@ -6,7 +6,7 @@ use kobold_qr::qr;
 fn qr_example() -> impl View {
     stateful("Enter something", |data| {
         let onkeyup = event!(|data, e: KeyboardEvent<HtmlTextAreaElement>| {
-            *data = e.target().value();
+            *data = e.current_target().value();
         });
 
         view! {

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -54,7 +54,7 @@ fn app(state: &Hook<State>) -> impl View + '_ {
 #[component]
 fn entry_input(state: &Hook<State>) -> impl View + '_ {
     let onchange = event!(|state, e: Event<InputElement>| {
-        let input = e.target();
+        let input = e.current_target();
         state.add(input.value());
 
         input.set_value("");
@@ -82,7 +82,7 @@ fn entry<'a>(idx: usize, entry: &'a Entry, state: &'a Hook<State>) -> impl View 
     let input = entry.editing.then(move || {
         let onkeypress = event!(move |state, e: KeyboardEvent<InputElement>| {
             if e.key() == "Enter" {
-                state.update(idx, e.target().value());
+                state.update(idx, e.current_target().value());
 
                 Then::Render
             } else {
@@ -90,14 +90,14 @@ fn entry<'a>(idx: usize, entry: &'a Entry, state: &'a Hook<State>) -> impl View 
             }
         });
         let onblur = event!(move |state, e: Event<InputElement>| {
-            state.update(idx, e.target().value());
+            state.update(idx, e.current_target().value());
         });
 
         view! {
             <input.edit
                 type="text"
                 value={static &entry.description}
-                onmouseover={|event| event.target().focus()}
+                onmouseover={|event| event.current_target().focus()}
                 {onkeypress}
                 {onblur}
             >

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -18,7 +18,7 @@ fn app(state: &Hook<State>) -> impl View + '_ {
                     <h1>"todos"</h1>
                     <!entry_input {state}>
                 </header>
-                <section .main.{hidden}>
+                <section.main.{hidden}>
                     <!toggle_all {active_count} {state}>
                     <ul.todo-list>
                         {


### PR DESCRIPTION
All over the place PR of stuff I needed fixing in the moment.

+ **BREAKING** `*Event<_>::target` now always returns `HtmlElement`, the typed `EventTarget<T>` is now only returned by `*Event<_>::current_target`.
+ You can now set `innerHTML` on elements:
```rust
let raw = "Hello <strong>World</strong>";

view! {
    <div html={raw} />
}
```
+ Fixed setting classes on SVG elements.
+ The `viewBox` attribute on the `<svg>` element is now aliased to `view_box` to keep it idiomatic with Rust.
+ `kobold_qr` now exposes the `Ecl` enum which the `<!qr>` component can take as a param to configure the level of error correction.