### PR TITLE
Simplify Router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "castaway"
@@ -246,8 +246,6 @@ version = "0.1.0"
 dependencies = [
  "kobold",
  "matchit",
- "serde",
- "serde-wasm-bindgen",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -327,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -364,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
 
 [[package]]
 name = "ryu"
@@ -381,17 +379,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -510,7 +497,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.58",
  "wasm-bindgen-shared",
 ]
 
@@ -544,7 +531,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.58",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/crates/kobold_router/Cargo.toml
+++ b/crates/kobold_router/Cargo.toml
@@ -16,9 +16,7 @@ documentation = "https://docs.rs/kobold"
 [dependencies]
 kobold = { path = "../kobold" }
 matchit = "0.8.0"
-serde = { version = "1.0.197", features = ["derive"] }
-serde-wasm-bindgen = "0.4"
-wasm-bindgen = "0.2.84"
+wasm-bindgen = "0.2.92"
 
 [dependencies.web-sys]
 version = "0.3"

--- a/crates/kobold_router/src/lib.rs
+++ b/crates/kobold_router/src/lib.rs
@@ -47,11 +47,14 @@ impl Router {
         V: View,
     {
         self.router
-            .insert(route, Box::new(move |params| {
-                let view = render(params);
+            .insert(
+                route,
+                Box::new(move |params| {
+                    let view = render(params);
 
-                start_route(view)
-            }))
+                    start_route(view)
+                }),
+            )
             .expect_throw("Failed to insert route");
     }
 

--- a/examples/router/src/main.rs
+++ b/examples/router/src/main.rs
@@ -1,17 +1,13 @@
 use kobold::prelude::*;
 use kobold::View;
-use kobold_router::get_param;
-use kobold_router::link;
-use kobold_router::route_view;
-use kobold_router::start_route;
-use kobold_router::Router;
+use kobold_router::{link, Params, Router};
 use wasm_bindgen::JsValue;
 use web_sys::console::error_1;
 use web_sys::HtmlInputElement;
 
 #[component]
-fn inventory() -> impl View + 'static {
-    let attempt_to_get_id = get_param::<usize>("id");
+fn inventory(params: Params) -> impl View + 'static {
+    let attempt_to_get_id = params.get("id");
 
     let id = match attempt_to_get_id {
         Ok(id) => Some(id),
@@ -76,26 +72,21 @@ fn route_two(state: &Hook<State>) -> impl View + '_ {
     }
 }
 
-fn get_router() -> Router {
+fn main() {
     let mut router = Router::new();
-    router.add_route(
-        "/",
-        route_view!(view! {
+
+    router.add_route("/", |_| {
+        view! {
             <h1>{"Welcome to the router example!"}</h1>
             <!link route={"/one"}>"View your first route here!"</!link>
 
-        }),
-    );
+        }
+    });
 
-    router.add_route("/one", route_view!(stateful(State::default, route_one)));
-    router.add_route("/two", route_view!(stateful(State::default, route_two)));
-    router.add_route("/inventory/{id}", route_view!(view!(<!inventory>)));
+    router.add_route("/one", |_| stateful(State::default, route_one));
+    router.add_route("/two", |_| stateful(State::default, route_two));
+    router.add_route("/inventory/{id}", |params| view!(<!inventory {params}>));
 
-    router
-}
-
-fn main() {
-    let mut router = get_router();
     router.start();
 }
 


### PR DESCRIPTION
Building upon #95:

+ The way it was built there was no reason for putting the router in an `Rc` that I can see.
+ I've removed the `Params` hashmap and the whole need to pass it over the browser state, instead a newtype wrapper over `matchit::Params` is being piped into the route functions.
+ The `Params::get` method replaces `get_param`.
+ I've hidden the `start_route` function in the `add_route` method and made it an implementation detail (removed `pub`).
+ Removed `route_view!` macro as `add_route` just accepts a regular `Fn(Params) -> impl View` closure.

The startup can also be simplified, but we'll need way to turn arbitrary `impl View` into a dynamic boxed view type (with a boxed product) first.