### PR TITLE
Minor tweaks to remove panic branches in TodoMVC

### DIFF
--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "esbuild": "^0.14.47"
+    "esbuild": "^0.20.2"
   },
   "scripts": {
     "minify": "mv ./dist/kobold_todomvc_example.js ./dist/kobold_todomvc_example_large.js && esbuild --bundle ./dist/kobold_todomvc_example_large.js --outfile=./dist/kobold_todomvc_example.js --minify --format=esm"

--- a/examples/todomvc/src/state.rs
+++ b/examples/todomvc/src/state.rs
@@ -118,11 +118,10 @@ impl State {
         if let Some(entry) = self.editing.and_then(|idx| self.entries.get_mut(idx)) {
             entry.editing = false;
         }
-
-        self.editing = Some(idx);
-        self.entries[idx].editing = true;
-
-        self.store();
+        if let Some(entry) = self.entries.get_mut(idx) {
+            self.editing = Some(idx);
+            entry.editing = true;
+        }
     }
 
     pub fn add(&mut self, description: String) {
@@ -142,7 +141,9 @@ impl State {
     }
 
     pub fn update(&mut self, idx: usize, description: String) {
-        let entry = &mut self.entries[idx];
+        let Some(entry) = self.entries.get_mut(idx) else {
+            return;
+        };
 
         entry.editing = false;
 
@@ -153,9 +154,10 @@ impl State {
     }
 
     pub fn toggle(&mut self, idx: usize) {
-        self.entries[idx].completed ^= true;
-
-        self.store();
+        if let Some(entry) = self.entries.get_mut(idx) {
+            entry.completed ^= true;
+            self.store();
+        }
     }
 }
 


### PR DESCRIPTION
This plus all the current changes in 0.10 bring TodoMVC example down to 28.53kb uncompressed (14.42kb gzipped), down from 31.53kb (15.86kb gzipped) with the 0.9.1 build.